### PR TITLE
Make python test suite uv runnable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ define install-service
 		sed -e "s|{{DESCRIPTION}}|$(3)|g" \
 			-e "s|{{USER}}|$$(whoami)|g" \
 			-e "s|{{WORKING_DIRECTORY}}|$(CURDIR)|g" \
-			-e "s|{{EXEC_START}}|$(UV_BIN) run scripts/$(4) $(5)|g" \
+			-e "s|{{EXEC_START}}|$(UV_BIN) run python -m $(4) $(5)|g" \
 			-e "s|{{RESTART_POLICY}}|always|g" \
 			-e "s|{{RESTART_SEC}}|$(6)|g" \
 			-e "s|{{GIT_BRANCH}}|$(CURRENT_BRANCH)|g" \
@@ -58,7 +58,7 @@ define install-service
 		sed -e "s|{{DESCRIPTION}}|$(3)|g" \
 			-e "s|{{USER}}|$$(whoami)|g" \
 			-e "s|{{WORKING_DIRECTORY}}|$(CURDIR)|g" \
-			-e "s|{{EXEC_START}}|$(UV_BIN) run scripts/$(4) --host $(SENSOR_HOST) --port $(SENSOR_PORT) $(5)|g" \
+			-e "s|{{EXEC_START}}|$(UV_BIN) run python -m $(4) --host $(SENSOR_HOST) --port $(SENSOR_PORT) $(5)|g" \
 			-e "s|{{RESTART_SEC}}|$(6)|g" \
 			-e "s|{{SENSOR_HOST}}|$(SENSOR_HOST)|g" \
 			-e "s|{{SENSOR_PORT}}|$(SENSOR_PORT)|g" \
@@ -107,7 +107,7 @@ define install-all-sensor-services
 		sed -e "s|{{DESCRIPTION}}|$(3)|g" \
 			-e "s|{{USER}}|$$(whoami)|g" \
 			-e "s|{{WORKING_DIRECTORY}}|$(CURDIR)|g" \
-			-e "s|{{EXEC_START}}|$(UV_BIN) run python3 scripts/$(4) $(5) --host $(SENSOR_HOST) --port $(SENSOR_PORT) $$RUN_COUNT_ARG|g" \
+			-e "s|{{EXEC_START}}|$(UV_BIN) run python -m $(4) $(5) --host $(SENSOR_HOST) --port $(SENSOR_PORT) $$RUN_COUNT_ARG|g" \
 			-e "s|{{RESTART_POLICY}}|$$RESTART_POLICY|g" \
 			-e "s|{{RESTART_SEC}}|$$RESTART_SEC|g" \
 			-e "s|{{SENSOR_HOST}}|$(SENSOR_HOST)|g" \
@@ -287,7 +287,7 @@ install-website-service: check-linux check-signalk-token
 		echo "Visit: https://github.com/astral-sh/uv"; \
 		exit 1; \
 	fi
-	$(call install-service,website,vessel-tracker,Vessel Tracker Data Updater,update_signalk_data.py,,600)
+	$(call install-service,website,vessel-tracker,Vessel Tracker Data Updater,scripts.update_signalk_data,,600)
 
 install-all-sensor-services: check-linux check-signalk-token
 	@if [ -z "$(UV_BIN)" ]; then \
@@ -311,7 +311,7 @@ install-bme280-service: check-linux check-signalk-token
 		echo "Visit: https://github.com/astral-sh/uv"; \
 		exit 1; \
 	fi
-	$(call install-all-sensor-services,bme280,vessel-sensor-bme280,BME280 Sensor Service,i2c_sensor_read_and_publish.py,bme280)
+	$(call install-all-sensor-services,bme280,vessel-sensor-bme280,BME280 Sensor Service,scripts.i2c_sensor_read_and_publish,bme280)
 
 install-bno055-service: check-linux check-signalk-token
 	@if [ -z "$(UV_BIN)" ]; then \
@@ -319,7 +319,7 @@ install-bno055-service: check-linux check-signalk-token
 		echo "Visit: https://github.com/astral-sh/uv"; \
 		exit 1; \
 	fi
-	$(call install-all-sensor-services,bno055,vessel-sensor-bno055,BNO055 Sensor Service,i2c_sensor_read_and_publish.py,bno055)
+	$(call install-all-sensor-services,bno055,vessel-sensor-bno055,BNO055 Sensor Service,scripts.i2c_sensor_read_and_publish,bno055)
 
 install-mmc5603-service: check-linux check-signalk-token
 	@if [ -z "$(UV_BIN)" ]; then \
@@ -327,7 +327,7 @@ install-mmc5603-service: check-linux check-signalk-token
 		echo "Visit: https://github.com/astral-sh/uv"; \
 		exit 1; \
 	fi
-	$(call install-all-sensor-services,mmc5603,vessel-sensor-mmc5603,MMC5603 Sensor Service,i2c_sensor_read_and_publish.py,mmc5603)
+	$(call install-all-sensor-services,mmc5603,vessel-sensor-mmc5603,MMC5603 Sensor Service,scripts.i2c_sensor_read_and_publish,mmc5603)
 
 install-sgp30-service: check-linux check-signalk-token
 	@if [ -z "$(UV_BIN)" ]; then \
@@ -335,7 +335,7 @@ install-sgp30-service: check-linux check-signalk-token
 		echo "Visit: https://github.com/astral-sh/uv"; \
 		exit 1; \
 	fi
-	$(call install-all-sensor-services,sgp30,vessel-sensor-sgp30,SGP30 Sensor Service,i2c_sensor_read_and_publish.py,sgp30)
+	$(call install-all-sensor-services,sgp30,vessel-sensor-sgp30,SGP30 Sensor Service,scripts.i2c_sensor_read_and_publish,sgp30)
 
 install-magnetic-service: check-linux check-signalk-token
 	@if [ -z "$(UV_BIN)" ]; then \
@@ -343,7 +343,7 @@ install-magnetic-service: check-linux check-signalk-token
 		echo "Visit: https://github.com/astral-sh/uv"; \
 		exit 1; \
 	fi
-	$(call install-service,magnetic,vessel-magnetic-variation,Vessel Magnetic Variation Service (daily),magnetic_variation_service.py,,86400)
+	$(call install-service,magnetic,vessel-magnetic-variation,Vessel Magnetic Variation Service (daily),scripts.magnetic_variation_service,,86400)
 
 # Individual service uninstallation
 uninstall-website-service: check-linux
@@ -451,7 +451,7 @@ status: check-linux
 	fi
 	@echo ""
 	@echo "--- SignalK Connection Status ---"
-	@if [ -n "$(UV_BIN)" ] && "$(UV_BIN)" run python3 scripts/signalk_token_management.py --check >/dev/null 2>&1; then \
+	@if [ -n "$(UV_BIN)" ] && "$(UV_BIN)" run python -m scripts.signalk_token_management --check >/dev/null 2>&1; then \
 		echo "SignalK Token: ✓ Valid"; \
 		echo "SignalK Server: $(SENSOR_HOST):$(SENSOR_PORT)"; \
 	else \
@@ -495,17 +495,17 @@ run-website-update:
 	fi
 	@echo "Running one website telemetry update..."
 	@echo "Fetching from SignalK and writing data..."; \
-	"$(UV_BIN)" run scripts/update_signalk_data.py --no-reset --amend --force-push --signalk-url "http://$(SENSOR_HOST):$(SENSOR_PORT)/signalk/v1/api/vessels/self" --output data/telemetry/signalk_latest.json
+	"$(UV_BIN)" run python -m scripts.update_signalk_data --no-reset --amend --force-push --signalk-url "http://$(SENSOR_HOST):$(SENSOR_PORT)/signalk/v1/api/vessels/self" --output data/telemetry/signalk_latest.json
 
 # Run tests
 test:
-	@if command -v uvx >/dev/null 2>&1; then \
-		echo "Running tests with uvx (no project sync required)..."; \
-		uvx pytest -q; \
-	else \
-		echo "Error: 'uvx' is not available. Ensure 'uv' is installed and on PATH."; \
+	@if [ -z "$(UV_BIN)" ]; then \
+		echo "Error: 'uv' is not installed. Please install uv first."; \
+		echo "Visit: https://github.com/astral-sh/uv"; \
 		exit 1; \
 	fi
+	@echo "Running tests with uv environment..."
+	@"$(UV_BIN)" run pytest $(PYTEST_ARGS)
 
 # Install pre-commit hooks
 pre-commit-install:
@@ -581,7 +581,7 @@ install-sensors: check-linux check-signalk-token
 	@echo "Installation complete!"
 	@echo ""
 	@echo "To run a specific sensor:"
-	@echo "  uv run scripts/i2c_sensor_read_and_publish.py bme280 --host 192.168.8.50 --port 3000"
+	@echo "  uv run python -m scripts.i2c_sensor_read_and_publish bme280 --host 192.168.8.50 --port 3000"
 	@echo ""
 	@echo "To run with custom settings:"
 	@echo "  make run-bme280 SENSOR_HOST=192.168.8.50 SENSOR_PORT=3000"
@@ -604,16 +604,16 @@ run-sensors: check-signalk-token
 	@echo "Note: Each sensor will run once, regardless of run_count in config"
 	@echo ""
 	@echo "Running BME280 sensor (one run)..."
-	@"$(UV_BIN)" run scripts/i2c_sensor_read_and_publish.py bme280 --host $(SENSOR_HOST) --port $(SENSOR_PORT) --run-count 1 || echo "BME280 failed"
+	@"$(UV_BIN)" run python -m scripts.i2c_sensor_read_and_publish bme280 --host $(SENSOR_HOST) --port $(SENSOR_PORT) --run-count 1 || echo "BME280 failed"
 	@echo ""
 	@echo "Running BNO055 sensor (one run)..."
-	@"$(UV_BIN)" run scripts/i2c_sensor_read_and_publish.py bno055 --host $(SENSOR_HOST) --port $(SENSOR_PORT) --run-count 1 || echo "BNO055 failed"
+	@"$(UV_BIN)" run python -m scripts.i2c_sensor_read_and_publish bno055 --host $(SENSOR_HOST) --port $(SENSOR_PORT) --run-count 1 || echo "BNO055 failed"
 	@echo ""
 	@echo "Running MMC5603 sensor (one run)..."
-	@"$(UV_BIN)" run scripts/i2c_sensor_read_and_publish.py mmc5603 --host $(SENSOR_HOST) --port $(SENSOR_PORT) --run-count 1 || echo "MMC5603 failed"
+	@"$(UV_BIN)" run python -m scripts.i2c_sensor_read_and_publish mmc5603 --host $(SENSOR_HOST) --port $(SENSOR_PORT) --run-count 1 || echo "MMC5603 failed"
 	@echo ""
 	@echo "Running SGP30 sensor (one run)..."
-	@"$(UV_BIN)" run scripts/i2c_sensor_read_and_publish.py sgp30 --host $(SENSOR_HOST) --port $(SENSOR_PORT) --run-count 1 || echo "SGP30 failed"
+	@"$(UV_BIN)" run python -m scripts.i2c_sensor_read_and_publish sgp30 --host $(SENSOR_HOST) --port $(SENSOR_PORT) --run-count 1 || echo "SGP30 failed"
 	@echo ""
 	@echo "All sensors completed (one run each)."
 
@@ -625,7 +625,7 @@ run-bme280: check-signalk-token
 		exit 1; \
 	fi
 	@echo "Starting BME280 sensor read and publish..."
-	@"$(UV_BIN)" run scripts/i2c_sensor_read_and_publish.py bme280 --host $(SENSOR_HOST) --port $(SENSOR_PORT)
+	@"$(UV_BIN)" run python -m scripts.i2c_sensor_read_and_publish bme280 --host $(SENSOR_HOST) --port $(SENSOR_PORT)
 
 run-bno055: check-signalk-token
 	@if [ -z "$(UV_BIN)" ]; then \
@@ -634,7 +634,7 @@ run-bno055: check-signalk-token
 		exit 1; \
 	fi
 	@echo "Starting BNO055 sensor read and publish..."
-	@"$(UV_BIN)" run scripts/i2c_sensor_read_and_publish.py bno055 --host $(SENSOR_HOST) --port $(SENSOR_PORT)
+	@"$(UV_BIN)" run python -m scripts.i2c_sensor_read_and_publish bno055 --host $(SENSOR_HOST) --port $(SENSOR_PORT)
 
 run-mmc5603: check-signalk-token
 	@if [ -z "$(UV_BIN)" ]; then \
@@ -643,7 +643,7 @@ run-mmc5603: check-signalk-token
 		exit 1; \
 	fi
 	@echo "Starting MMC5603 sensor read and publish..."
-	@"$(UV_BIN)" run scripts/i2c_sensor_read_and_publish.py mmc5603 --host $(SENSOR_HOST) --port $(SENSOR_PORT)
+	@"$(UV_BIN)" run python -m scripts.i2c_sensor_read_and_publish mmc5603 --host $(SENSOR_HOST) --port $(SENSOR_PORT)
 
 run-sgp30: check-signalk-token
 	@if [ -z "$(UV_BIN)" ]; then \
@@ -652,7 +652,7 @@ run-sgp30: check-signalk-token
 		exit 1; \
 	fi
 	@echo "Starting SGP30 sensor read and publish..."
-	@"$(UV_BIN)" run scripts/i2c_sensor_read_and_publish.py sgp30 --host $(SENSOR_HOST) --port $(SENSOR_PORT)
+	@"$(UV_BIN)" run python -m scripts.i2c_sensor_read_and_publish sgp30 --host $(SENSOR_HOST) --port $(SENSOR_PORT)
 
 run-magnetic-service: check-signalk-token
 	@if [ -z "$(UV_BIN)" ]; then \
@@ -662,7 +662,7 @@ run-magnetic-service: check-signalk-token
 	fi
 	@echo "Starting magnetic variation service (one-time run)..."
 	@echo "Service will calculate and publish magnetic variation once, then exit."
-	@timeout 30 "$(UV_BIN)" run scripts/magnetic_variation_service.py --host $(SENSOR_HOST) --port $(SENSOR_PORT) --interval 86400 || [ $$? -eq 124 ] && echo "Magnetic variation service completed (timeout expected)"
+	@timeout 30 "$(UV_BIN)" run python -m scripts.magnetic_variation_service --host $(SENSOR_HOST) --port $(SENSOR_PORT) --interval 86400 || [ $$? -eq 124 ] && echo "Magnetic variation service completed (timeout expected)"
 
 # Check I2C devices and permissions
 check-i2c: check-linux
@@ -689,13 +689,13 @@ check-i2c: check-linux
 # Check SignalK token
 check-signalk-token:
 	@echo "Checking SignalK token..."
-	@"$(UV_BIN)" run python3 scripts/signalk_token_management.py --check || ( \
+	@"$(UV_BIN)" run python -m scripts.signalk_token_management --check || ( \
 		echo ""; \
 		echo "SignalK token is missing or invalid."; \
 		echo "To create a token, run one of these commands:"; \
 		echo "  make create-signalk-token      # Create SignalK token"; \
 		echo "  make config                    # Interactive vessel configuration"; \
-		echo "  $(UV_BIN) run python3 scripts/signalk_token_management.py  # Direct token request"; \
+		echo "  $(UV_BIN) run python -m scripts.signalk_token_management  # Direct token request"; \
 		exit 1 \
 	)
 
@@ -709,7 +709,7 @@ create-signalk-token:
 	@echo ""
 	@read -p "Continue? (y/N): " confirm && [ "$$confirm" = "y" ] || exit 1
 	@echo ""
-	@"$(UV_BIN)" run python3 scripts/signalk_token_management.py --host $(SENSOR_HOST) --port $(SENSOR_PORT) --timeout 300
+	@"$(UV_BIN)" run python -m scripts.signalk_token_management --host $(SENSOR_HOST) --port $(SENSOR_PORT) --timeout 300
 	@echo ""
 	@echo "Token creation completed!"
 	@echo "You can now run sensor-related commands:"
@@ -719,7 +719,7 @@ create-signalk-token:
 # Interactive vessel configuration wizard
 config:
 	@echo "Starting Vessel Configuration Wizard..."
-	@"$(UV_BIN)" run python3 scripts/vessel_config_wizard.py
+	@"$(UV_BIN)" run python -m scripts.vessel_config_wizard
 
 # Calibrate magnetic heading sensor offset
 calibrate-mmc5603: check-linux
@@ -733,7 +733,7 @@ calibrate-mmc5603: check-linux
 	@echo "You'll need to know the current true heading of your vessel."
 	@echo ""
 	@echo "Running heading calibration with uv: $(UV_BIN)"
-	@"$(UV_BIN)" run python scripts/calibrate_mmc5603_heading.py
+	@"$(UV_BIN)" run python -m scripts.calibrate_mmc5603_heading
 
 # Calibrate BNO055 IMU sensor
 calibrate-bno055: check-linux
@@ -747,7 +747,7 @@ calibrate-bno055: check-linux
 	@echo "The sensor requires calibration for accurate orientation and motion data."
 	@echo ""
 	@echo "Running IMU calibration with uv: $(UV_BIN)"
-	@"$(UV_BIN)" run python scripts/calibrate_bno055_imu.py
+	@"$(UV_BIN)" run python -m scripts.calibrate_bno055_imu
 
 # Calibrate SGP30 air quality sensor
 calibrate-sgp30: check-linux
@@ -761,4 +761,4 @@ calibrate-sgp30: check-linux
 	@echo "The sensor measures TVOC and eCO2 and requires baseline calibration."
 	@echo ""
 	@echo "Running air quality calibration with uv: $(UV_BIN)"
-	@"$(UV_BIN)" run python scripts/calibrate_sgp30_air_quality.py
+	@"$(UV_BIN)" run python -m scripts.calibrate_sgp30_air_quality

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,8 @@ quote-style = "double"
 indent-style = "space"
 skip-magic-trailing-comma = false
 line-ending = "auto"
+
+[tool.pytest.ini_options]
+pythonpath = [
+    ".",
+]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Project scripts package."""

--- a/scripts/calibrate_bno055_imu.py
+++ b/scripts/calibrate_bno055_imu.py
@@ -36,7 +36,7 @@ from bno055_register_io import (
 )
 
 # Import vessel info loading from utils
-from utils import load_vessel_info, save_vessel_info as save_vessel_info_util
+from .utils import load_vessel_info, save_vessel_info as save_vessel_info_util
 
 
 def get_heading_true_from_signalk(vessel_info):

--- a/scripts/calibrate_mmc5603_heading.py
+++ b/scripts/calibrate_mmc5603_heading.py
@@ -21,7 +21,7 @@ import board
 import busio
 
 # Import vessel info loading from utils
-from utils import load_vessel_info, save_vessel_info as save_vessel_info_util
+from .utils import load_vessel_info, save_vessel_info as save_vessel_info_util
 
 
 def save_vessel_info(info, info_path="data/vessel/info.yaml"):

--- a/scripts/calibrate_sgp30_air_quality.py
+++ b/scripts/calibrate_sgp30_air_quality.py
@@ -23,7 +23,7 @@ import busio
 from adafruit_sgp30 import Adafruit_SGP30
 
 # Import vessel info loading from utils
-from utils import load_vessel_info, save_vessel_info as save_vessel_info_util
+from .utils import load_vessel_info, save_vessel_info as save_vessel_info_util
 
 
 def save_vessel_info(info, info_path="data/vessel/info.yaml"):

--- a/scripts/i2c_sensor_read_and_publish.py
+++ b/scripts/i2c_sensor_read_and_publish.py
@@ -23,7 +23,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from sensors import BME280Sensor, BNO055Sensor, MMC5603Sensor, SGP30Sensor
-from utils import load_vessel_info, send_delta_over_udp, setup_logging
+from .utils import load_vessel_info, send_delta_over_udp, setup_logging
 
 # Constants
 DEFAULT_UDP_PORT = 4123

--- a/scripts/magnetic_variation_service.py
+++ b/scripts/magnetic_variation_service.py
@@ -23,7 +23,7 @@ except ImportError:
     geomag = None
 
 # Import utilities
-from utils import (
+from .utils import (
     load_vessel_info,
     send_delta_over_udp,
     setup_logging,

--- a/scripts/sensors/base.py
+++ b/scripts/sensors/base.py
@@ -17,7 +17,7 @@ from typing import Any
 # Add scripts directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from utils import load_vessel_info, send_delta_over_udp
+from ..utils import load_vessel_info, send_delta_over_udp
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/signalk_token_management.py
+++ b/scripts/signalk_token_management.py
@@ -14,7 +14,7 @@ import uuid
 import requests
 
 # Import utilities (used in multiple methods)
-from utils import load_vessel_info, save_vessel_info
+from .utils import load_vessel_info, save_vessel_info
 
 
 class SignalKTokenRequester:

--- a/scripts/update_signalk_data.py
+++ b/scripts/update_signalk_data.py
@@ -9,7 +9,10 @@ from typing import Any
 
 import requests
 
-from utils import get_project_root, load_vessel_info
+try:  # Support both `python scripts/...` and `python -m scripts...`
+    from .utils import get_project_root, load_vessel_info
+except ImportError:  # When run as a standalone script
+    from utils import get_project_root, load_vessel_info
 
 DEFAULT_OUTPUT_FILE = "./data/telemetry/signalk_latest.json"
 STALE_MAX_AGE_MINUTES = 60

--- a/scripts/update_signalk_data.py
+++ b/scripts/update_signalk_data.py
@@ -9,10 +9,7 @@ from typing import Any
 
 import requests
 
-try:  # Support both `python scripts/...` and `python -m scripts...`
-    from .utils import get_project_root, load_vessel_info
-except ImportError:  # When run as a standalone script
-    from utils import get_project_root, load_vessel_info
+from .utils import get_project_root, load_vessel_info
 
 DEFAULT_OUTPUT_FILE = "./data/telemetry/signalk_latest.json"
 STALE_MAX_AGE_MINUTES = 60

--- a/scripts/vessel_config_wizard.py
+++ b/scripts/vessel_config_wizard.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import requests
 
-from utils import load_vessel_info, save_vessel_info
+from .utils import load_vessel_info, save_vessel_info
 
 
 class VesselConfigWizard:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import subprocess
 import tempfile
@@ -8,12 +9,21 @@ import pytest
 import requests
 
 
+SIGNALK_CHECK_ENV = os.getenv("SIGNALK_VERIFY_FOR_TESTS", "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
+
+
 @pytest.fixture(autouse=True)
 def check_signalk_running():
     """
     Autouse fixture that checks if SignalK is running on the specified port and URL
     from info.json before each test. This ensures tests only run when SignalK is available.
     """
+    if not SIGNALK_CHECK_ENV:
+        return
     # Read SignalK configuration from info.json
     info_path = Path(__file__).parent.parent / "data" / "vessel" / "info.json"
 

--- a/tests/test_update_signalk_data.py
+++ b/tests/test_update_signalk_data.py
@@ -7,6 +7,10 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
 
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
 import scripts.update_signalk_data as usd
 
 
@@ -87,24 +91,12 @@ def test_run_on_dev_branch_writes_file_and_calls_git(tmp_path, test_branch):
 
     # Patch both requests module and subprocess.run
     with (
-        patch.dict(sys.modules, {"requests": FakeRequests}),
-        patch("subprocess.run", side_effect=fake_run),
+        patch("scripts.update_signalk_data.requests", FakeRequests),
+        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
     ):
-        # Prepare module under test
-        import importlib
-        from pathlib import Path
-
-        # Add the project root to Python path using the test file location as reference
-        test_file_dir = Path(__file__).parent
-        project_root = test_file_dir.parent
-        sys.path.insert(0, str(project_root))
-
-        mod = importlib.import_module("scripts.update_signalk_data")
-
-        # Use a path inside tmp
         out = tmp_path / "signalk_latest.json"
 
-        mod.run_update(
+        usd.run_update(
             branch=test_branch,
             remote="origin",
             signalk_url="http://example",  # mocked
@@ -153,20 +145,12 @@ def test_https_conversion(tmp_path, test_branch):
         return R()
 
     with (
-        patch.dict(sys.modules, {"requests": FakeRequests}),
-        patch("subprocess.run", side_effect=fake_run),
+        patch("scripts.update_signalk_data.requests", FakeRequests),
+        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
     ):
-        import importlib
-
-        test_file_dir = Path(__file__).parent
-        project_root = test_file_dir.parent
-        sys.path.insert(0, str(project_root))
-
-        mod = importlib.import_module("scripts.update_signalk_data")
-
         out = tmp_path / "signalk_latest.json"
 
-        mod.run_update(
+        usd.run_update(
             branch=test_branch,
             remote="origin",
             signalk_url="http://example.com:3000/api",
@@ -208,20 +192,12 @@ def test_no_reset_mode(tmp_path, test_branch):
         return R()
 
     with (
-        patch.dict(sys.modules, {"requests": FakeRequests}),
-        patch("subprocess.run", side_effect=fake_run),
+        patch("scripts.update_signalk_data.requests", FakeRequests),
+        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
     ):
-        import importlib
-
-        test_file_dir = Path(__file__).parent
-        project_root = test_file_dir.parent
-        sys.path.insert(0, str(project_root))
-
-        mod = importlib.import_module("scripts.update_signalk_data")
-
         out = tmp_path / "signalk_latest.json"
 
-        mod.run_update(
+        usd.run_update(
             branch=test_branch,
             remote="origin",
             signalk_url="http://example.com/api",
@@ -265,20 +241,12 @@ def test_amend_commit(tmp_path, test_branch):
         return R()
 
     with (
-        patch.dict(sys.modules, {"requests": FakeRequests}),
-        patch("subprocess.run", side_effect=fake_run),
+        patch("scripts.update_signalk_data.requests", FakeRequests),
+        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
     ):
-        import importlib
-
-        test_file_dir = Path(__file__).parent
-        project_root = test_file_dir.parent
-        sys.path.insert(0, str(project_root))
-
-        mod = importlib.import_module("scripts.update_signalk_data")
-
         out = tmp_path / "signalk_latest.json"
 
-        mod.run_update(
+        usd.run_update(
             branch=test_branch,
             remote="origin",
             signalk_url="http://example.com/api",
@@ -323,20 +291,12 @@ def test_force_push(tmp_path, test_branch):
         return R()
 
     with (
-        patch.dict(sys.modules, {"requests": FakeRequests}),
-        patch("subprocess.run", side_effect=fake_run),
+        patch("scripts.update_signalk_data.requests", FakeRequests),
+        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
     ):
-        import importlib
-
-        test_file_dir = Path(__file__).parent
-        project_root = test_file_dir.parent
-        sys.path.insert(0, str(project_root))
-
-        mod = importlib.import_module("scripts.update_signalk_data")
-
         out = tmp_path / "signalk_latest.json"
 
-        mod.run_update(
+        usd.run_update(
             branch=test_branch,
             remote="origin",
             signalk_url="http://example.com/api",
@@ -381,20 +341,12 @@ def test_no_push_mode(tmp_path, test_branch):
         return R()
 
     with (
-        patch.dict(sys.modules, {"requests": FakeRequests}),
-        patch("subprocess.run", side_effect=fake_run),
+        patch("scripts.update_signalk_data.requests", FakeRequests),
+        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
     ):
-        import importlib
-
-        test_file_dir = Path(__file__).parent
-        project_root = test_file_dir.parent
-        sys.path.insert(0, str(project_root))
-
-        mod = importlib.import_module("scripts.update_signalk_data")
-
         out = tmp_path / "signalk_latest.json"
 
-        mod.run_update(
+        usd.run_update(
             branch=test_branch,
             remote="origin",
             signalk_url="http://example.com/api",
@@ -431,22 +383,14 @@ def test_requests_error_handling(tmp_path, test_branch):
         return R()
 
     with (
-        patch.dict(sys.modules, {"requests": FakeRequests}),
-        patch("subprocess.run", side_effect=fake_run),
+        patch("scripts.update_signalk_data.requests", FakeRequests),
+        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
     ):
-        import importlib
-
-        test_file_dir = Path(__file__).parent
-        project_root = test_file_dir.parent
-        sys.path.insert(0, str(project_root))
-
-        mod = importlib.import_module("scripts.update_signalk_data")
-
         out = tmp_path / "signalk_latest.json"
 
         # Should raise an exception when requests fails
         try:
-            mod.run_update(
+            usd.run_update(
                 branch=test_branch,
                 remote="origin",
                 signalk_url="http://example.com/api",
@@ -464,7 +408,6 @@ def test_requests_error_handling(tmp_path, test_branch):
             assert not out.exists()
 
 
-@patch.dict(sys.modules, {"requests": None})
 def test_integration_updates_test_branch(tmp_path, test_branch):
     def run(cmd, cwd=None):
         subprocess.run(cmd, check=True, cwd=cwd)
@@ -523,23 +466,14 @@ def test_integration_updates_test_branch(tmp_path, test_branch):
             return FakeResp()
 
     # Patch the requests module with our fake implementation
-    with patch.dict(sys.modules, {"requests": FakeRequests}):
-        # Import the script module from the project under test
-        test_file_dir = Path(__file__).parent
-        project_root = test_file_dir.parent
-        sys.path.insert(0, str(project_root))
-        import importlib
-
-        mod = importlib.import_module("scripts.update_signalk_data")
-
-        # Run from within the working repo
+    with patch("scripts.update_signalk_data.requests", FakeRequests):
         out = work / "signalk_latest.json"
 
         # Change to the working directory before running the script
         original_cwd = os.getcwd()
         try:
             os.chdir(work)
-            mod.run_update(
+            usd.run_update(
                 branch=test_branch,
                 remote="origin",
                 signalk_url="http://example",

--- a/tests/test_update_signalk_data.py
+++ b/tests/test_update_signalk_data.py
@@ -1,15 +1,10 @@
 import json
 import os
 import subprocess
-import sys
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch
-
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
 
 import scripts.update_signalk_data as usd
 


### PR DESCRIPTION
Make the Python test suite runnable with `uv` by fixing module imports and making the SignalK service dependency optional.

The previous test setup had issues with module imports when run via `uv run pytest` due to differences in how `uv` handles the Python path and module loading. Additionally, tests were skipped if a live SignalK service wasn't running, which is not ideal for local development or CI environments. This PR addresses these by adjusting import paths, explicitly patching dependencies, and introducing an environment variable to control the SignalK availability check.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1da119c-9d6d-4e1a-b16d-be1340610fb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f1da119c-9d6d-4e1a-b16d-be1340610fb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Run all scripts as Python modules via `python -m`, fix imports to package-relative, and update tests/config to run cleanly under `uv`.
> 
> - **Build/Services (Makefile)**:
>   - Execute scripts via `python -m` (e.g., `scripts.update_signalk_data`, `scripts.i2c_sensor_read_and_publish`, `scripts.magnetic_variation_service`, `scripts.signalk_token_management`).
>   - Update systemd install commands and run targets to use module paths; adjust website/sensor/magnetic service installers and status checks accordingly.
>   - Replace test target to run with `"$(UV_BIN)" run pytest`.
> - **Python packaging/imports**:
>   - Add `scripts/__init__.py` to make `scripts` a package.
>   - Convert absolute imports to relative (e.g., `from .utils ...`, `from ..utils ...`) across calibration, sensors base, token management, magnetic service, and update script.
> - **Testing**:
>   - Add `pytest` `pythonpath = ["."]` in `pyproject.toml`.
>   - Simplify tests to import `scripts.update_signalk_data` directly and patch `requests`/`subprocess` within that module.
>   - Introduce `SIGNALK_VERIFY_FOR_TESTS` env-gated SignalK availability check in `tests/conftest.py`.
> - **CLI usage**:
>   - Update Makefile help/examples and commands to reflect module-based invocation for all scripts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb596a5f03476ce53a640937e55af6d8943d4e49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->