### PR TITLE
Sensor import error resolution

### DIFF
--- a/scripts/i2c_sensor_read_and_publish.py
+++ b/scripts/i2c_sensor_read_and_publish.py
@@ -19,11 +19,17 @@ import time
 from datetime import UTC, datetime
 from pathlib import Path
 
-# Add scripts directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent))
-
-from sensors import BME280Sensor, BNO055Sensor, MMC5603Sensor, SGP30Sensor
-from .utils import load_vessel_info, send_delta_over_udp, setup_logging
+# Ensure imports work both when executed as a module (`python -m scripts...`)
+# and when executed as a file (`python scripts/...py`).
+if __package__ in (None, ""):
+    # Running as a script: add project root so `import scripts.*` works.
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    from scripts.sensors import BME280Sensor, BNO055Sensor, MMC5603Sensor, SGP30Sensor
+    from scripts.utils import load_vessel_info, send_delta_over_udp, setup_logging
+else:
+    # Running as a module inside the `scripts` package.
+    from .sensors import BME280Sensor, BNO055Sensor, MMC5603Sensor, SGP30Sensor
+    from .utils import load_vessel_info, send_delta_over_udp, setup_logging
 
 # Constants
 DEFAULT_UDP_PORT = 4123


### PR DESCRIPTION
Refactor imports in `i2c_sensor_read_and_publish.py` to resolve `ImportError` caused by inconsistent Python package context.

The `ImportError` occurred because `i2c_sensor_read_and_publish.py` was importing `sensors` as a top-level module, which broke relative imports (e.g., `from ..utils`) within `scripts/sensors/base.py`. This change ensures `sensors` and `utils` are consistently imported as part of the `scripts` package, whether the file is run directly or as a module.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ddc6c9d-3e17-4597-bbb1-707f5b32c544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1ddc6c9d-3e17-4597-bbb1-707f5b32c544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `i2c_sensor_read_and_publish.py` imports robust for both module and script execution by conditionally adjusting `sys.path` and using package-qualified imports for `sensors` and `utils`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2271e9da94633663b62f57170f47500cca070192. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->