### PR TITLE
Remove JWT token from version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ config.ini
 secrets.json
 .env.local
 .env.production
+data/vessel/signalk_token.txt
 
 # System files
 .DS_Store

--- a/data/vessel/info.yaml
+++ b/data/vessel/info.yaml
@@ -6,7 +6,6 @@ signalk:
   host: "192.168.8.50"
   port: "3000"
   protocol: "http"
-  token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkZXZpY2UiOiJpMmMtc2Vuc29ycy0yNjFkZDVhNCIsImlhdCI6MTc1ODY0MTU3NCwiZXhwIjoxNzkwMTk5MTc0fQ.6EHOPfv7V9e6UYedwTngc2Ac2Ppqj5YaaQwiERPXS9c"
 sensors:
   # Per-sensor configuration with update intervals (in seconds)
   bme280:

--- a/scripts/vessel_config_wizard.py
+++ b/scripts/vessel_config_wizard.py
@@ -82,9 +82,18 @@ class VesselConfigWizard:
         else:
             return input(f"{prompt}: ").strip()
 
+    TOKEN_FILE = "data/vessel/signalk_token.txt"
+
+    def _read_token(self) -> str | None:
+        """Read the SignalK token from the gitignored token file."""
+        try:
+            return Path(self.TOKEN_FILE).read_text().strip() or None
+        except FileNotFoundError:
+            return None
+
     def test_existing_token(self) -> bool:
         """Test if the existing token is valid."""
-        token = self.config["signalk"].get("token")
+        token = self._read_token()
         if not token:
             print("No token to test.")
             return False
@@ -218,7 +227,7 @@ class VesselConfigWizard:
         print("\n--- SignalK Token Management ---")
 
         # Check if token exists
-        existing_token = self.config["signalk"].get("token")
+        existing_token = self._read_token()
         if existing_token:
             print(f"Existing token found: {existing_token[:20]}...")
             token_action = self.get_input(


### PR DESCRIPTION
The SignalK auth token was hardcoded in data/vessel/info.yaml, which is
committed to the repo. The static GitHub Pages site never uses it, and
the on-vessel Python scripts can store it locally instead.

- Remove token field from data/vessel/info.yaml
- Add data/vessel/signalk_token.txt to .gitignore as the new token store
- signalk_token_management.py: save/load/check token via the txt file
  instead of info.yaml; update --token-file default accordingly
- vessel_config_wizard.py: read token from the txt file via _read_token()

The existing token should be rotated in the SignalK admin UI.

https://claude.ai/code/session_017GvSWdc3dq2weTyg6es6dc