### PR TITLE
feat: backfill 213 historical track positions (Jan 31 – Feb 7)

### DIFF
--- a/data/telemetry/positions_index.json
+++ b/data/telemetry/positions_index.json
@@ -1,6 +1,4479 @@
 {
   "positions": [
     {
+      "timestamp": "2026-01-31T16:42:20.035000+00:00",
+      "file": "2026-01-31T16-42-20.035000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7823313,
+            "longitude": -122.384475
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.08
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.8547725470574254
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T16:44:53.216000+00:00",
+      "file": "2026-01-31T16-44-53.216000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.785354833333336,
+            "longitude": -122.38242166666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.100277777777778
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.03479255440970608
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T16:47:27.027000+00:00",
+      "file": "2026-01-31T16-47-27.027000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7883028,
+            "longitude": -122.3831635
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.8
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.997090456753022
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T16:49:59.965000+00:00",
+      "file": "2026-01-31T16-49-59.965000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7919075,
+            "longitude": -122.385734
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.3508333333333336
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.660410350268466
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T16:52:35.451000+00:00",
+      "file": "2026-01-31T16-52-35.451000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.795646166666664,
+            "longitude": -122.38831116666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.8086111111111114
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.912130509320541
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T16:55:09.404000+00:00",
+      "file": "2026-01-31T16-55-09.404000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.79954133333333,
+            "longitude": -122.39026366666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.8922222222222222
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.825250012008446
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T16:57:43.160000+00:00",
+      "file": "2026-01-31T16-57-43.160000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.803182166666666,
+            "longitude": -122.392479
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.9941666666666666
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.898769075303019
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:00:17.847000+00:00",
+      "file": "2026-01-31T17-00-17.847000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8066123,
+            "longitude": -122.3955182
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.16
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.622089604018945
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:02:52.128000+00:00",
+      "file": "2026-01-31T17-02-52.128000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.80994233333333,
+            "longitude": -122.39988933333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 4.062777777777778
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.220213364728318
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:05:26.028000+00:00",
+      "file": "2026-01-31T17-05-26.028000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8125657,
+            "longitude": -122.40453
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.11
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.994435307046748
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:08:00.123000+00:00",
+      "file": "2026-01-31T17-08-00.123000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.81429633333333,
+            "longitude": -122.40965583333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.253611111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.022855341565739
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:10:34.305000+00:00",
+      "file": "2026-01-31T17-10-34.305000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.815568,
+            "longitude": -122.41487566666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.9716666666666667
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.645673903172493
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:13:08.866000+00:00",
+      "file": "2026-01-31T17-13-08.866000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.815778,
+            "longitude": -122.4200703
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.96
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.774388708909666
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:15:43.001000+00:00",
+      "file": "2026-01-31T17-15-43.001000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8161175,
+            "longitude": -122.4246573
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.68
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.759202268988606
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:18:16.898000+00:00",
+      "file": "2026-01-31T17-18-16.898000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8166487,
+            "longitude": -122.4298643
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.101111111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.966118180305042
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:20:50.749000+00:00",
+      "file": "2026-01-31T17-20-50.749000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8179502,
+            "longitude": -122.4352763
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.2
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.473737406249451
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:23:24.871000+00:00",
+      "file": "2026-01-31T17-23-24.871000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8182135,
+            "longitude": -122.4385975
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.7816666666666665
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.7530473276545553
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:25:58.818000+00:00",
+      "file": "2026-01-31T17-25-58.818000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8191543,
+            "longitude": -122.4364585
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.220833333333333
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.008759592893674117
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:28:33.310000+00:00",
+      "file": "2026-01-31T17-28-33.310000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.821556333333334,
+            "longitude": -122.43511233333334
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.658611111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 6.062249964657742
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:31:07.127000+00:00",
+      "file": "2026-01-31T17-31-07.127000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8239613,
+            "longitude": -122.4343258
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.75
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 6.124156443822791
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:33:41.281000+00:00",
+      "file": "2026-01-31T17-33-41.281000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.82654433333333,
+            "longitude": -122.43324266666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.239444444444444
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 6.14946281565653
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:36:16.693000+00:00",
+      "file": "2026-01-31T17-36-16.693000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.82947866,
+            "longitude": -122.4320175
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.27
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 6.11277006875903
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:38:50.800000+00:00",
+      "file": "2026-01-31T17-38-50.800000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8281553,
+            "longitude": -122.4322347
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.56
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.8203658846470128
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:41:24.245000+00:00",
+      "file": "2026-01-31T17-41-24.245000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.82600633333333,
+            "longitude": -122.43210683333334
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.6230555555555555
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.729357802827691
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:43:58.181000+00:00",
+      "file": "2026-01-31T17-43-58.181000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8231465,
+            "longitude": -122.433091
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.8713888888888888
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.724150189425865
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:46:32.219000+00:00",
+      "file": "2026-01-31T17-46-32.219000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8200365,
+            "longitude": -122.4346715
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.1169444444444445
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.180543208558753
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:49:07.071000+00:00",
+      "file": "2026-01-31T17-49-07.071000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8191558,
+            "longitude": -122.4383367
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.33
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.625249883987047
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:51:41.204000+00:00",
+      "file": "2026-01-31T17-51-41.204000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.81696766666666,
+            "longitude": -122.442503
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.833888888888889
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.640253227738258
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:54:16.152000+00:00",
+      "file": "2026-01-31T17-54-16.152000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.814819666666665,
+            "longitude": -122.44365066666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.3288888888888888
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.9969485604995825
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:56:50.324000+00:00",
+      "file": "2026-01-31T17-56-50.324000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.813553166666665,
+            "longitude": -122.44534783333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.3772222222222223
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.14594852905922
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T17:59:23.986000+00:00",
+      "file": "2026-01-31T17-59-23.986000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8116237,
+            "longitude": -122.4466463
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.72
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.5829450751332663
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:01:58.189000+00:00",
+      "file": "2026-01-31T18-01-58.189000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.810323333333336,
+            "longitude": -122.4486725
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.5530555555555556
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.3744458279581915
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:04:31.423000+00:00",
+      "file": "2026-01-31T18-04-31.423000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.80924066666667,
+            "longitude": -122.44823533333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.54
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.7157407518209595
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:07:05.443000+00:00",
+      "file": "2026-01-31T18-07-05.443000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8089985,
+            "longitude": -122.44788
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.051388888888889
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.4063389191579976
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:09:39.157000+00:00",
+      "file": "2026-01-31T18-09-39.157000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.808955,
+            "longitude": -122.446089
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.5599999999999999
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.39173400392345
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:12:14.826000+00:00",
+      "file": "2026-01-31T18-12-14.826000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8093443,
+            "longitude": -122.4439277
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.38
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.053429541226963
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:14:48.211000+00:00",
+      "file": "2026-01-31T18-14-48.211000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.810095,
+            "longitude": -122.44187883333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.5933333333333333
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.1792268779834156
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:17:22.174000+00:00",
+      "file": "2026-01-31T18-17-22.174000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.811752,
+            "longitude": -122.43822366666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.781111111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.2477228616110423
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:19:57.066000+00:00",
+      "file": "2026-01-31T18-19-57.066000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8131067,
+            "longitude": -122.4333058
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.34
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.348614509275777
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:22:31.740000+00:00",
+      "file": "2026-01-31T18-22-31.740000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8141963,
+            "longitude": -122.4283518
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.3427777777777776
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.2853051485252132
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:25:06.287000+00:00",
+      "file": "2026-01-31T18-25-06.287000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.814930833333335,
+            "longitude": -122.424941
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.2641666666666667
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.4081985567399409
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:27:39.789000+00:00",
+      "file": "2026-01-31T18-27-39.789000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8155455,
+            "longitude": -122.42216883
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.43
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.4669932990869734
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:30:13.380000+00:00",
+      "file": "2026-01-31T18-30-13.380000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.81632283333333,
+            "longitude": -122.4186895
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.9363888888888887
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.271786720188763
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:32:47.023000+00:00",
+      "file": "2026-01-31T18-32-47.023000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8174133,
+            "longitude": -122.413795
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.95
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.9173774512943553
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:35:21.260000+00:00",
+      "file": "2026-01-31T18-35-21.260000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8165095,
+            "longitude": -122.40895316666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.8380555555555556
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.8572611453958097
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:37:55.432000+00:00",
+      "file": "2026-01-31T18-37-55.432000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.815382,
+            "longitude": -122.4041265
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.8636111111111107
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.0535440696977854
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:40:31.933000+00:00",
+      "file": "2026-01-31T18-40-31.933000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.814273666666665,
+            "longitude": -122.39916716666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.1525
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.8970266986914261
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:43:22.193000+00:00",
+      "file": "2026-01-31T18-43-22.193000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.812984666666665,
+            "longitude": -122.3936295
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.973611111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.039207109590765
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:46:09.242000+00:00",
+      "file": "2026-01-31T18-46-09.242000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.81119916666667,
+            "longitude": -122.38867233333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.9786111111111113
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.9321880169388093
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:48:44.476000+00:00",
+      "file": "2026-01-31T18-48-44.476000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.809743166666664,
+            "longitude": -122.38391466666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.8844444444444446
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.9548692740814557
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:51:18.458000+00:00",
+      "file": "2026-01-31T18-51-18.458000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.808144166666665,
+            "longitude": -122.379707
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.2622222222222224
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.2369520706027206
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:53:52.978000+00:00",
+      "file": "2026-01-31T18-53-52.978000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8068023,
+            "longitude": -122.3760082
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.1
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.167537237781491
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:56:27.308000+00:00",
+      "file": "2026-01-31T18-56-27.308000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.80549466666667,
+            "longitude": -122.37295133333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.1399999999999997
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.8734243184937267
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T18:59:01.987000+00:00",
+      "file": "2026-01-31T18-59-01.987000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8040703,
+            "longitude": -122.3696602
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.75
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.174310228817874
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:01:36.324000+00:00",
+      "file": "2026-01-31T19-01-36.324000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.803142333333334,
+            "longitude": -122.36733666666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.8777777777777778
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.7684005971445071
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:04:09.858000+00:00",
+      "file": "2026-01-31T19-04-09.858000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.80254,
+            "longitude": -122.3646533
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.65
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.7708911605866735
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:06:43.740000+00:00",
+      "file": "2026-01-31T19-06-43.740000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8026532,
+            "longitude": -122.3618845
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.47
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.2359840618312492
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:09:17.273000+00:00",
+      "file": "2026-01-31T19-09-17.273000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.80358566666666,
+            "longitude": -122.3604155
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.8019444444444445
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.190483479382057
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:11:50.994000+00:00",
+      "file": "2026-01-31T19-11-50.994000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.804566,
+            "longitude": -122.35969
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.6825
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.0458849769919643
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:14:27.133000+00:00",
+      "file": "2026-01-31T19-14-27.133000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8061773,
+            "longitude": -122.3588175
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.52
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.43738839640834526
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:17:01.149000+00:00",
+      "file": "2026-01-31T19-17-01.149000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8099177,
+            "longitude": -122.3577523
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.79
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.21721363811298566
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:19:35.189000+00:00",
+      "file": "2026-01-31T19-19-35.189000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.812991,
+            "longitude": -122.35696816666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.216944444444444
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.6524078475488887
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:22:09.154000+00:00",
+      "file": "2026-01-31T19-22-09.154000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8163185,
+            "longitude": -122.3551435
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.74
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.47751486320109704
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:24:42.906000+00:00",
+      "file": "2026-01-31T19-24-42.906000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8181413,
+            "longitude": -122.3576845
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.06
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.140328293916976
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:27:17.016000+00:00",
+      "file": "2026-01-31T19-27-17.016000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.820116,
+            "longitude": -122.3591183
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.06
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.7831392689897184
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:29:51.234000+00:00",
+      "file": "2026-01-31T19-29-51.234000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.823154833333334,
+            "longitude": -122.357646
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.225
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.7189463017334894
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:32:25.351000+00:00",
+      "file": "2026-01-31T19-32-25.351000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.82463716666667,
+            "longitude": -122.35970583333334
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.5916666666666668
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.905157095341293
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:35:00.149000+00:00",
+      "file": "2026-01-31T19-35-00.149000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8260505,
+            "longitude": -122.3623025
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.84
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.906769203525269
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:37:34.415000+00:00",
+      "file": "2026-01-31T19-37-34.415000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8271525,
+            "longitude": -122.3656015
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.408611111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.19178209253728
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:40:08.251000+00:00",
+      "file": "2026-01-31T19-40-08.251000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.829483333333336,
+            "longitude": -122.3652985
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.8391666666666668
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.48428964222791104
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:42:42.484000+00:00",
+      "file": "2026-01-31T19-42-42.484000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.832072,
+            "longitude": -122.36524766666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.075833333333333
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.2256988016508129
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:45:17.136000+00:00",
+      "file": "2026-01-31T19-45-17.136000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.83469666,
+            "longitude": -122.36501866
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.08
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.4493076078501234
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:47:50.968000+00:00",
+      "file": "2026-01-31T19-47-50.968000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8372903,
+            "longitude": -122.3651618
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.66
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.080117310688534
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:50:25.020000+00:00",
+      "file": "2026-01-31T19-50-25.020000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8386373,
+            "longitude": -122.3671548
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.29
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.983827543050307
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:52:58.642000+00:00",
+      "file": "2026-01-31T19-52-58.642000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.83987116666667,
+            "longitude": -122.36928516666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.797222222222222
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.998237672292679
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:55:33.197000+00:00",
+      "file": "2026-01-31T19-55-33.197000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.841105166666665,
+            "longitude": -122.37176516666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.7586111111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.255848791162439
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T19:58:07.208000+00:00",
+      "file": "2026-01-31T19-58-07.208000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.84260533333333,
+            "longitude": -122.37456533333334
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.8777777777777778
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.214961847053244
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:00:41.859000+00:00",
+      "file": "2026-01-31T20-00-41.859000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8452677,
+            "longitude": -122.3792087
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.56
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.289983974560447
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:03:16.201000+00:00",
+      "file": "2026-01-31T20-03-16.201000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.848136,
+            "longitude": -122.38506416666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 4.2844444444444445
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.290810114717444
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:05:51.334000+00:00",
+      "file": "2026-01-31T20-05-51.334000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.85097366,
+            "longitude": -122.3916255
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.8
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.035438043609386
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:08:25.011000+00:00",
+      "file": "2026-01-31T20-08-25.011000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8540612,
+            "longitude": -122.3944072
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.16
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.3046566529735796
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:10:58.277000+00:00",
+      "file": "2026-01-31T20-10-58.277000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.85865,
+            "longitude": -122.39416233333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.6783333333333337
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.29327248462272715
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:13:32.061000+00:00",
+      "file": "2026-01-31T20-13-32.061000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8608753,
+            "longitude": -122.3973243
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.53
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.226389019742832
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:16:06.329000+00:00",
+      "file": "2026-01-31T20-16-06.329000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.86259416666667,
+            "longitude": -122.40325816666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.420833333333333
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.092311115100001
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:18:40.985000+00:00",
+      "file": "2026-01-31T20-18-40.985000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8654232,
+            "longitude": -122.402915
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.24
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.41152045408503335
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:21:15.143000+00:00",
+      "file": "2026-01-31T20-21-15.143000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8693695,
+            "longitude": -122.401585
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.0294444444444446
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.3711310481262219
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:23:50.090000+00:00",
+      "file": "2026-01-31T20-23-50.090000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.872357,
+            "longitude": -122.4016347
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.25
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 4.9471419185595416
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:26:24.897000+00:00",
+      "file": "2026-01-31T20-26-24.897000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.873444,
+            "longitude": -122.4056903
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.2330555555555556
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.5512567676640814
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:28:59.342000+00:00",
+      "file": "2026-01-31T20-28-59.342000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.87595233333333,
+            "longitude": -122.40357583333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.8205555555555555
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.5557600738256536
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:31:33.364000+00:00",
+      "file": "2026-01-31T20-31-33.364000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.87763616666667,
+            "longitude": -122.40147366666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.7141666666666666
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.6287604725811954
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:34:08.834000+00:00",
+      "file": "2026-01-31T20-34-08.834000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.879081,
+            "longitude": -122.3995123
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.91
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.7878603389339197
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:36:43.973000+00:00",
+      "file": "2026-01-31T20-36-43.973000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8804917,
+            "longitude": -122.3970835
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.85
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.8728588429071663
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:39:18.214000+00:00",
+      "file": "2026-01-31T20-39-18.214000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8819228,
+            "longitude": -122.3937107
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.23
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.9264548681301863
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:41:52.233000+00:00",
+      "file": "2026-01-31T20-41-52.233000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.883325666666664,
+            "longitude": -122.39003333333334
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.5316666666666667
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.1224499647722013
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:44:26.300000+00:00",
+      "file": "2026-01-31T20-44-26.300000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.88491466666667,
+            "longitude": -122.38905216666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.5450000000000004
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.707053018072956
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:47:02.005000+00:00",
+      "file": "2026-01-31T20-47-02.005000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.887428666666665,
+            "longitude": -122.39230666666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.560277777777778
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.691970849534964
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:49:36.786000+00:00",
+      "file": "2026-01-31T20-49-36.786000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8904675,
+            "longitude": -122.395582
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.535277777777778
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.779790622491459
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:52:10.930000+00:00",
+      "file": "2026-01-31T20-52-10.930000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.893118,
+            "longitude": -122.39866033333334
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.457777777777778
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.765608464505538
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:54:45.899000+00:00",
+      "file": "2026-01-31T20-54-45.899000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8960177,
+            "longitude": -122.4014567
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.71
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.682726438968721
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:57:19.257000+00:00",
+      "file": "2026-01-31T20-57-19.257000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.899059,
+            "longitude": -122.40459
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.770833333333333
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.801645831618041
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T20:59:53.206000+00:00",
+      "file": "2026-01-31T20-59-53.206000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.90220083333333,
+            "longitude": -122.40698666666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.7580555555555555
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.906563595105972
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:02:28.143000+00:00",
+      "file": "2026-01-31T21-02-28.143000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.90561666666667,
+            "longitude": -122.40819283333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.4491666666666667
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 6.019779129710203
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:05:02.975000+00:00",
+      "file": "2026-01-31T21-05-02.975000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.9089517,
+            "longitude": -122.4109848
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.93
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.733798653795318
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:07:37.972000+00:00",
+      "file": "2026-01-31T21-07-37.972000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.9119848,
+            "longitude": -122.4142283
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.62
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.812018308670184
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:10:12.210000+00:00",
+      "file": "2026-01-31T21-10-12.210000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.91535833333333,
+            "longitude": -122.41677816666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.9344444444444444
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.899337315214983
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:12:47.382000+00:00",
+      "file": "2026-01-31T21-12-47.382000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.91835716666667,
+            "longitude": -122.41881466666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.7602777777777776
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.811153588222684
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:15:23.196000+00:00",
+      "file": "2026-01-31T21-15-23.196000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.91961633333333,
+            "longitude": -122.4199715
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.5222222222222224
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.76746123000647
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:17:57.238000+00:00",
+      "file": "2026-01-31T21-17-57.238000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.92153366666667,
+            "longitude": -122.42161916666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.1827777777777775
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.942672562887197
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:20:31.053000+00:00",
+      "file": "2026-01-31T21-20-31.053000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.9239035,
+            "longitude": -122.423066
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.13
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.74548498181982
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:23:06.021000+00:00",
+      "file": "2026-01-31T21-23-06.021000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.9262018,
+            "longitude": -122.4247745
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.41
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 6.035497848420713
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:25:39.203000+00:00",
+      "file": "2026-01-31T21-25-39.203000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.92789916666667,
+            "longitude": -122.426137
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.5916666666666667
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.916207620041664
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:28:14.909000+00:00",
+      "file": "2026-01-31T21-28-14.909000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.929222,
+            "longitude": -122.4282278
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.48
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.797718006314004
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:30:49.130000+00:00",
+      "file": "2026-01-31T21-30-49.130000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.929696,
+            "longitude": -122.427417
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.28
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.58241751905597
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:33:23.186000+00:00",
+      "file": "2026-01-31T21-33-23.186000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.93086666666667,
+            "longitude": -122.43000266666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.669722222222222
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.3566286907292
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:35:58.379000+00:00",
+      "file": "2026-01-31T21-35-58.379000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.928547,
+            "longitude": -122.4331245
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.25
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.683628746127769
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:38:32.174000+00:00",
+      "file": "2026-01-31T21-38-32.174000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.92431,
+            "longitude": -122.43446133333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.1313888888888886
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.7265170416899283
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:41:06.571000+00:00",
+      "file": "2026-01-31T21-41-06.571000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.919772333333334,
+            "longitude": -122.4360015
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.3758333333333335
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.5786049049526922
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:43:41.392000+00:00",
+      "file": "2026-01-31T21-43-41.392000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.91503,
+            "longitude": -122.43718916666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.3119444444444444
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.5948910223146444
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:46:16.133000+00:00",
+      "file": "2026-01-31T21-46-16.133000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.9101795,
+            "longitude": -122.437401
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 4.003611111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.3013742710310447
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:48:50.692000+00:00",
+      "file": "2026-01-31T21-48-50.692000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.9042877,
+            "longitude": -122.4373988
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 4.488888888888889
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.214152926890811
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:51:25.296000+00:00",
+      "file": "2026-01-31T21-51-25.296000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.897756666666666,
+            "longitude": -122.4367865
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 4.925833333333333
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.065027772467139
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:54:00.914000+00:00",
+      "file": "2026-01-31T21-54-00.914000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.89087166666667,
+            "longitude": -122.4355355
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 5.059444444444444
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.0639996263568503
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:56:35.927000+00:00",
+      "file": "2026-01-31T21-56-35.927000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.88385,
+            "longitude": -122.434425
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 5.04
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.310471367459713
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T21:59:10.738000+00:00",
+      "file": "2026-01-31T21-59-10.738000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.876505,
+            "longitude": -122.43640233333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 5.525
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.601050254080941
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:01:45.427000+00:00",
+      "file": "2026-01-31T22-01-45.427000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.87128283333333,
+            "longitude": -122.44162516666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 4.855277777777777
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.7492453816123477
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:04:20.382000+00:00",
+      "file": "2026-01-31T22-04-20.382000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.86625883333333,
+            "longitude": -122.44775866666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 5.304722222222223
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.574443902820129
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:07:04.579000+00:00",
+      "file": "2026-01-31T22-07-04.579000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.86009,
+            "longitude": -122.452004
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 4.688055555555555
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.4203330997448997
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:09:53.669000+00:00",
+      "file": "2026-01-31T22-09-53.669000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8528842,
+            "longitude": -122.4554483
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 4.87
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.403016472552275
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:12:28.229000+00:00",
+      "file": "2026-01-31T22-12-28.229000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.84609283333333,
+            "longitude": -122.45908683333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 5.604444444444444
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.512101725001764
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:15:02.618000+00:00",
+      "file": "2026-01-31T22-15-02.618000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.839379,
+            "longitude": -122.462396
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 4.171388888888889
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.7241864322050575
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:17:36.790000+00:00",
+      "file": "2026-01-31T22-17-36.790000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8339682,
+            "longitude": -122.4633397
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 4.42
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.196669483563349
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:20:12.129000+00:00",
+      "file": "2026-01-31T22-20-12.129000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8276735,
+            "longitude": -122.4675208
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 5.53
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.5697580291885607
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:22:48.266000+00:00",
+      "file": "2026-01-31T22-22-48.266000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.821242,
+            "longitude": -122.471403
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 4.757499999999999
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.1397452752461428
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:25:22.548000+00:00",
+      "file": "2026-01-31T22-25-22.548000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.816901,
+            "longitude": -122.47221533333334
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.7986111111111107
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.4027319241028033
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:27:56.816000+00:00",
+      "file": "2026-01-31T22-27-56.816000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8129778,
+            "longitude": -122.4702863
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.5050000000000003
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.124912529024493
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:30:31.122000+00:00",
+      "file": "2026-01-31T22-30-31.122000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8103063,
+            "longitude": -122.467073
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.950594301534234
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:33:04.859000+00:00",
+      "file": "2026-01-31T22-33-04.859000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8101852,
+            "longitude": -122.4623058
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.94
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.6038810849082876
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:35:39.001000+00:00",
+      "file": "2026-01-31T22-35-39.001000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8097003,
+            "longitude": -122.4573863
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.88
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.5733661444957232
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:38:13.799000+00:00",
+      "file": "2026-01-31T22-38-13.799000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8098602,
+            "longitude": -122.4523655
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.04
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.511653243451366
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:40:47.219000+00:00",
+      "file": "2026-01-31T22-40-47.219000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.81010666666667,
+            "longitude": -122.44743866666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.2663888888888892
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.3291409030431027
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:43:22.299000+00:00",
+      "file": "2026-01-31T22-43-22.299000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.81090966666667,
+            "longitude": -122.44269166666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.5658333333333334
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.237231038584084
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:45:57.434000+00:00",
+      "file": "2026-01-31T22-45-57.434000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8119505,
+            "longitude": -122.43863283333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.446944444444444
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.247923872041444
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:48:31.369000+00:00",
+      "file": "2026-01-31T22-48-31.369000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.81318016666667,
+            "longitude": -122.434237
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.5375
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.2499164739037978
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:51:06.159000+00:00",
+      "file": "2026-01-31T22-51-06.159000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.814583166666665,
+            "longitude": -122.43007683333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.241111111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.281410327081784
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:53:40.883000+00:00",
+      "file": "2026-01-31T22-53-40.883000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8159,
+            "longitude": -122.4267515
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.28
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.2947061110872067
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:56:15.273000+00:00",
+      "file": "2026-01-31T22-56-15.273000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.816371333333336,
+            "longitude": -122.42370166666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.3041666666666667
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.479999587815143
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T22:58:49.231000+00:00",
+      "file": "2026-01-31T22-58-49.231000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.81676483333333,
+            "longitude": -122.42131983333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.3944444444444444
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.4611945886314552
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:01:23.913000+00:00",
+      "file": "2026-01-31T23-01-23.913000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8172797,
+            "longitude": -122.4187507
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.56
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.4543895156567124
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:03:58.580000+00:00",
+      "file": "2026-01-31T23-03-58.580000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.817817,
+            "longitude": -122.4164415
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.506111111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.3978852214829212
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:06:32.231000+00:00",
+      "file": "2026-01-31T23-06-32.231000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8180305,
+            "longitude": -122.41521433333334
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.038888888888889
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.468082676171022
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:09:06.198000+00:00",
+      "file": "2026-01-31T23-09-06.198000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.81844533333334,
+            "longitude": -122.4141655
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.6605555555555556
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.5109813349089665
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:11:40.915000+00:00",
+      "file": "2026-01-31T23-11-40.915000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8186278,
+            "longitude": -122.4135373
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.13
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.6126802909312667
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:14:14.960000+00:00",
+      "file": "2026-01-31T23-14-14.960000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8190663,
+            "longitude": -122.412754
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.53
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.5484797497131888
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:16:48.889000+00:00",
+      "file": "2026-01-31T23-16-48.889000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8197453,
+            "longitude": -122.412034
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.98
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.5379802437921364
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:19:23.413000+00:00",
+      "file": "2026-01-31T23-19-23.413000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.820445666666664,
+            "longitude": -122.41055233333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.1277777777777775
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.4929787264246943
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:21:57.196000+00:00",
+      "file": "2026-01-31T23-21-57.196000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.821113833333335,
+            "longitude": -122.40876866666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.303611111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.5084763490948612
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:24:32.325000+00:00",
+      "file": "2026-01-31T23-24-32.325000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.820932166666665,
+            "longitude": -122.40759216666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.8783333333333333
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.711272516341042
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:27:07.284000+00:00",
+      "file": "2026-01-31T23-27-07.284000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8210922,
+            "longitude": -122.4060343
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.14
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.7387688836515125
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:29:41.905000+00:00",
+      "file": "2026-01-31T23-29-41.905000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8212358,
+            "longitude": -122.4031238
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.16
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.7314615429166305
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:32:16.474000+00:00",
+      "file": "2026-01-31T23-32-16.474000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.82195333333333,
+            "longitude": -122.39903016666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.409444444444444
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.7366530709431816
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:34:51.495000+00:00",
+      "file": "2026-01-31T23-34-51.495000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8219415,
+            "longitude": -122.39456533333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.6841666666666666
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.6947410380026917
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:37:26.129000+00:00",
+      "file": "2026-01-31T23-37-26.129000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.821134,
+            "longitude": -122.390801
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.9055555555555557
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.1470279752829167
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:40:01.063000+00:00",
+      "file": "2026-01-31T23-40-01.063000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8207213,
+            "longitude": -122.3863735
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.87
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.8792144410260039
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:42:35.256000+00:00",
+      "file": "2026-01-31T23-42-35.256000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8197135,
+            "longitude": -122.381093
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.651944444444444
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.9859965379490325
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:45:09.774000+00:00",
+      "file": "2026-01-31T23-45-09.774000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8160967,
+            "longitude": -122.38098
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.04
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.315583222503829
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:47:44.422000+00:00",
+      "file": "2026-01-31T23-47-44.422000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8123915,
+            "longitude": -122.38237983333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.7527777777777778
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.1700736168091153
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:50:20.388000+00:00",
+      "file": "2026-01-31T23-50-20.388000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.80926483333333,
+            "longitude": -122.38347
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.8091666666666666
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.12236541863536
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:52:54.968000+00:00",
+      "file": "2026-01-31T23-52-54.968000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8065282,
+            "longitude": -122.3846725
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.85
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.112258780542668
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:55:29.170000+00:00",
+      "file": "2026-01-31T23-55-29.170000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.803789,
+            "longitude": -122.38566033333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.6724999999999999
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.1886515942945195
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-01-31T23:58:03.165000+00:00",
+      "file": "2026-01-31T23-58-03.165000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8011515,
+            "longitude": -122.38648683333334
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.8083333333333331
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.1199444102973
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-01T00:00:38.993000+00:00",
+      "file": "2026-02-01T00-00-38.993000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7985942,
+            "longitude": -122.3870882
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.72
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.0894368107714922
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-01T00:03:13.873000+00:00",
+      "file": "2026-02-01T00-03-13.873000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7964392,
+            "longitude": -122.3870087
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.88
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.647228790704513
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-01T00:05:48.256000+00:00",
+      "file": "2026-02-01T00-05-48.256000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7946645,
+            "longitude": -122.38691966666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.2722222222222221
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.8969221624870523
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-01T00:08:22.148000+00:00",
+      "file": "2026-02-01T00-08-22.148000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.79320383333334,
+            "longitude": -122.3854925
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.2116666666666667
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.6858130489844387
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-01T00:10:56.322000+00:00",
+      "file": "2026-02-01T00-10-56.322000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.791981666666665,
+            "longitude": -122.38427816666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.4169444444444443
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.794605367428001
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-01T00:13:30.408000+00:00",
+      "file": "2026-02-01T00-13-30.408000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.790381833333335,
+            "longitude": -122.3832475
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.1366666666666665
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.9145968398731017
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-01T00:16:05.225000+00:00",
+      "file": "2026-02-01T00-16-05.225000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.788867,
+            "longitude": -122.38296416666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.2227777777777777
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.70829060546984
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-01T00:18:40.158000+00:00",
+      "file": "2026-02-01T00-18-40.158000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7882288,
+            "longitude": -122.3826422
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.6225
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.5614874336996465
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-01T00:21:14.260000+00:00",
+      "file": "2026-02-01T00-21-14.260000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.787461,
+            "longitude": -122.38323916666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.380277777777778
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.211486278781498
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-01T00:23:48.154000+00:00",
+      "file": "2026-02-01T00-23-48.154000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.78435866666667,
+            "longitude": -122.38412283333334
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.2944444444444443
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 3.2867775312344696
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:00:25.110000+00:00",
+      "file": "2026-02-07T21-00-25.110000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.782481833333335,
+            "longitude": -122.38369066666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.651111111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.1065402442681502
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:03:01.821000+00:00",
+      "file": "2026-02-07T21-03-01.821000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7811927,
+            "longitude": -122.3817915
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.8905555555555555
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.905230333167765
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:05:42.804000+00:00",
+      "file": "2026-02-07T21-05-42.804000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.77878,
+            "longitude": -122.381075
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.39
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.270819718969771
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:08:18.314000+00:00",
+      "file": "2026-02-07T21-08-18.314000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.777184,
+            "longitude": -122.3802435
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.26
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.8666117293272952
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:10:52.957000+00:00",
+      "file": "2026-02-07T21-10-52.957000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7754383,
+            "longitude": -122.3799488
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.56
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.9913046506894028
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:13:28.339000+00:00",
+      "file": "2026-02-07T21-13-28.339000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.773674166666666,
+            "longitude": -122.37782666666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.8616666666666666
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 2.036192570782958
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:16:03.766000+00:00",
+      "file": "2026-02-07T21-16-03.766000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7719142,
+            "longitude": -122.3754337
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.84
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.9714797715438335
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:18:38.335000+00:00",
+      "file": "2026-02-07T21-18-38.335000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7713282,
+            "longitude": -122.3737787
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.6
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.20308787735001932
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:21:12.333000+00:00",
+      "file": "2026-02-07T21-21-12.333000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.771747,
+            "longitude": -122.37292766666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.6363888888888889
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.2176870738422867
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:23:47.302000+00:00",
+      "file": "2026-02-07T21-23-47.302000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.77257566666667,
+            "longitude": -122.371572
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.0044444444444445
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.36077174142972973
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:26:21.381000+00:00",
+      "file": "2026-02-07T21-26-21.381000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.77311266666667,
+            "longitude": -122.37034633333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.6519444444444444
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.3960703195443801
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:28:56.210000+00:00",
+      "file": "2026-02-07T21-28-56.210000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.773162666666664,
+            "longitude": -122.369624
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.22361111111111112
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.03898315939603059
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:31:31.183000+00:00",
+      "file": "2026-02-07T21-31-31.183000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.77292216666667,
+            "longitude": -122.3682865
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.8322222222222222
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 0.7163642224363536
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:34:06.361000+00:00",
+      "file": "2026-02-07T21-34-06.361000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.772472666666665,
+            "longitude": -122.36665333333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 0.9724999999999999
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.0256579811273088
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:36:41.087000+00:00",
+      "file": "2026-02-07T21-36-41.087000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.77213,
+            "longitude": -122.363839
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.86
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.5912491272704565
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:39:15.957000+00:00",
+      "file": "2026-02-07T21-39-15.957000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7717333,
+            "longitude": -122.3583022
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.18
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.4926328195857983
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:41:50.874000+00:00",
+      "file": "2026-02-07T21-41-50.874000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.77087,
+            "longitude": -122.35334666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.98
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 1.4659161755931243
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:44:26.345000+00:00",
+      "file": "2026-02-07T21-44-26.345000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.77177983333333,
+            "longitude": -122.35132
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.786111111111111
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.933413945294966
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:47:01.122000+00:00",
+      "file": "2026-02-07T21-47-01.122000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7741038,
+            "longitude": -122.3540752
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.28
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.462029751188114
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:49:36.588000+00:00",
+      "file": "2026-02-07T21-49-36.588000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.776673333333335,
+            "longitude": -122.35743066666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.1847222222222222
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.498448063396841
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:52:11.457000+00:00",
+      "file": "2026-02-07T21-52-11.457000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.778970666666666,
+            "longitude": -122.359908
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.547222222222222
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.513463169182019
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:54:47.117000+00:00",
+      "file": "2026-02-07T21-54-47.117000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7812695,
+            "longitude": -122.36282633333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.884722222222222
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.494079169956523
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:57:22.840000+00:00",
+      "file": "2026-02-07T21-57-22.840000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7837525,
+            "longitude": -122.3666418
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 3.135277777777778
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.349598233454195
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T21:59:57.280000+00:00",
+      "file": "2026-02-07T21-59-57.280000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.78654566666667,
+            "longitude": -122.368571
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.5305555555555554
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.853813658121818
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T22:02:32.425000+00:00",
+      "file": "2026-02-07T22-02-32.425000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.78826683333333,
+            "longitude": -122.36884283333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.272777777777778
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 6.1883204484136005
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T22:05:07.741000+00:00",
+      "file": "2026-02-07T22-05-07.741000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.79088,
+            "longitude": -122.368855
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.01
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 6.042029987991339
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T22:07:42.860000+00:00",
+      "file": "2026-02-07T22-07-42.860000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.7932042,
+            "longitude": -122.3694022
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.006388888888889
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.722439809661909
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T22:10:16.926000+00:00",
+      "file": "2026-02-07T22-10-16.926000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.79553083333333,
+            "longitude": -122.37100616666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.194166666666667
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.724852501647844
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T22:12:52.321000+00:00",
+      "file": "2026-02-07T22-12-52.321000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.79855,
+            "longitude": -122.37246366666666
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.332777777777778
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.666967285648482
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T22:15:27.139000+00:00",
+      "file": "2026-02-07T22-15-27.139000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.80038616666667,
+            "longitude": -122.37354266666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 1.4880555555555557
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.802676794646764
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T22:18:02.190000+00:00",
+      "file": "2026-02-07T22-18-02.190000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.80273966666667,
+            "longitude": -122.37413883333333
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.0055555555555555
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.964386856790946
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T22:20:37.899000+00:00",
+      "file": "2026-02-07T22-20-37.899000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.8054432,
+            "longitude": -122.3749007
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.0580555555555553
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.781798624992555
+        }
+      ]
+    },
+    {
+      "timestamp": "2026-02-07T22:23:13.303000+00:00",
+      "file": "2026-02-07T22-23-13.303000Z.json",
+      "values": [
+        {
+          "path": "navigation.position",
+          "value": {
+            "latitude": 37.80778266666667,
+            "longitude": -122.37660216666667
+          }
+        },
+        {
+          "path": "navigation.speedOverGround",
+          "value": 2.0469444444444442
+        },
+        {
+          "path": "navigation.courseOverGroundTrue",
+          "value": 5.663211505243439
+        }
+      ]
+    },
+    {
       "timestamp": "2026-02-07T22:25:48.941000+00:00",
       "latitude": 37.8098748,
       "longitude": -122.3786105,


### PR DESCRIPTION
Extract position data from the 4,400 snapshot archive files committed
in e3f770d that were never indexed in positions_index.json.

- Scanned all snapshot files for navigation.position in numericValues
- Applied the 200 m South Beach Harbor privacy exclusion zone
- 3,982 positions inside the geofence skipped (already scrubbed)
- 213 new entries added covering three trips:
    2026-01-31: 170 points (lat 37.78–37.93, extended sail up the bay)
    2026-02-01:  10 points (lat 37.78–37.80, short excursion)
    2026-02-07:  33 points (lat 37.77–37.81, local trip)
- New entries written in compact SignalK-values format:
    {timestamp, file, values:[{path, value},...]}
  (consistent with what update_signalk_data.py now generates)
- Existing 205 legacy-format entries from Feb 7–10 retained unchanged
- Total positions_index.json: 418 entries, Jan 31 – Feb 10
- All 213 new entries fall within the current 24-day display window

https://claude.ai/code/session_012B3wspbG1TAQs1Mep23VKC