### PR TITLE
Narrative tracker UX: stale tense, passage banner, crew tools, panel …

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -200,12 +200,19 @@ async function updateMapLocation(lat, lon) {
 function setStatusSentence(locationName) {
   const el = document.getElementById('status-sentence');
   if (!el) return;
+  const isStale = document.getElementById('status-hero')?.classList.contains('stale');
   if (vesselState === 'underway') {
-    el.textContent = `Underway near ${locationName}`;
+    el.textContent = isStale
+      ? `Last seen underway near ${locationName}`
+      : `Underway near ${locationName}`;
   } else if (vesselState === 'at anchor') {
-    el.textContent = `At anchor in ${locationName}`;
+    el.textContent = isStale
+      ? `Last seen at anchor in ${locationName}`
+      : `At anchor in ${locationName}`;
   } else {
-    el.textContent = `In ${locationName}`;
+    el.textContent = isStale
+      ? `Last seen in ${locationName}`
+      : `In ${locationName}`;
   }
 }
 
@@ -575,10 +582,22 @@ function updateVesselLinks() {
       logoImg.alt = `${vesselData.name} Logo`;
     }
 
-    // Update WiFi note
-    const wifiNote = document.querySelector('.wifi-note');
-    if (wifiNote) {
-      wifiNote.textContent = `*Only works on ${vesselData.name} WiFi`;
+  }
+
+  // Render passage banner if a current passage is configured
+  const passage = vesselData.passage;
+  const passageBanner = document.getElementById('passage-banner');
+  if (passageBanner) {
+    if (passage?.from && passage?.to) {
+      let text = `${passage.from} → ${passage.to}`;
+      if (passage.departed) {
+        const d = new Date(`${passage.departed}T12:00:00`);
+        text += ` · Departed ${d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}`;
+      }
+      passageBanner.textContent = text;
+      passageBanner.style.display = 'block';
+    } else {
+      passageBanner.style.display = 'none';
     }
   }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -113,6 +113,33 @@ body {
   width: 100%;
 }
 
+.passage-banner {
+  margin: 16px 20px 0;
+  padding: 10px 16px;
+  border-radius: 6px;
+  background: var(--bg-quaternary);
+  border: 1px solid var(--border-color);
+  font-size: 0.9em;
+  color: var(--text-secondary);
+  letter-spacing: 0.01em;
+}
+
+.crew-tools {
+  margin-top: 12px;
+  font-size: 0.85em;
+  color: var(--text-muted);
+}
+
+.crew-tools summary {
+  cursor: pointer;
+  user-select: none;
+  color: var(--text-muted);
+}
+
+.crew-tools summary:hover {
+  color: var(--text-secondary);
+}
+
 .info-panel {
   flex: 1;
   display: flex;
@@ -325,14 +352,6 @@ body {
   background-color: #1a232c;
 }
 
-.wifi-note {
-  font-size: 0.9em;
-  font-style: italic;
-  text-align: center;
-  color: var(--text-muted);
-  margin-top: 10px;
-  transition: color 0.3s ease;
-}
 
 .polar-performance-grid {
   display: grid;

--- a/data/vessel/info.yaml
+++ b/data/vessel/info.yaml
@@ -1,3 +1,10 @@
+# Optional: set during passages to show voyage context on the public tracker.
+# Edit via GitHub web UI or SSH before departing; clear when arrived.
+# passage:
+#   from: "San Francisco, CA"
+#   to: "Santa Cruz, CA"
+#   departed: "2026-02-20"
+
 name: "S.V.Mermug"
 mmsi: "338543654"
 uscg_number: "1024168"

--- a/index.html
+++ b/index.html
@@ -29,16 +29,23 @@
       <div id="map"></div>
     </div>
 
+    <!-- PASSAGE BANNER -->
+    <div id="passage-banner" class="passage-banner" style="display:none;"></div>
+
     <!-- LINKS -->
     <div style="margin: 20px;">
-      <div class="button-row" style="justify-content: space-between; gap: 10px;">
-        <a href="#" id="signalk-admin-link" target="_blank" class="action-btn signal-btn">Open SignalK*</a>
-        <a href="#" id="signalk-freeboard-link" target="_blank" class="action-btn plotter-btn">Open Freeboard-SK*</a>
-        <a href="#" id="signalk-anchor-alarm-link" target="_blank" class="action-btn anchor-btn">Anchor Alarm*</a>
+      <div class="button-row" style="justify-content: flex-end; gap: 10px;">
         <a href="#" id="marinetraffic-link" target="_blank" class="action-btn ais-btn">MarineTraffic</a>
         <a href="#" id="myshiptracking-link" target="_blank" class="action-btn ais-btn">MyShipTracking</a>
       </div>
-      <p class="wifi-note">*Only works on vessel WiFi</p>
+      <details class="crew-tools">
+        <summary>Crew tools (vessel WiFi only)</summary>
+        <div class="button-row" style="margin-top: 10px; gap: 10px;">
+          <a href="#" id="signalk-admin-link" target="_blank" class="action-btn signal-btn">Open SignalK</a>
+          <a href="#" id="signalk-freeboard-link" target="_blank" class="action-btn plotter-btn">Open Freeboard-SK</a>
+          <a href="#" id="signalk-anchor-alarm-link" target="_blank" class="action-btn anchor-btn">Anchor Alarm</a>
+        </div>
+      </details>
     </div>
 
     <!-- ALERT SUMMARY -->
@@ -50,10 +57,53 @@
       <div class="data-grid" id="navigation-grid"></div>
     </div>
 
+    <!-- TIDE CHART -->
+    <div class="info-panel" style="margin: 20px;">
+      <div id="tideHeader" class="panel-title" style="padding-top: 10px; margin-bottom: 0;"></div>
+      <canvas id="tideChart"></canvas>
+    </div>
+
+    <!-- WIND FORECAST -->
+    <div class="info-panel" style="margin: 20px;">
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">
+        <div id="windHeader" class="panel-title" style="flex: 1; margin-bottom: 0;">Wind Forecast at Current Location</div>
+        <select id="forecast-model" style="padding: 8px 12px; border-radius: 6px; border: 1px solid var(--border-color); background: var(--bg-secondary); color: var(--text-primary); font-size: 0.9em; cursor: pointer;">
+          <option value="wttr">wttr.in</option>
+          <option value="ecmwf">ECMWF</option>
+        </select>
+      </div>
+      <div class="wind-forecast-grid" id="wind-forecast-grid">
+        <div class="wind-forecast-item">
+          <div class="wind-time">Loading...</div>
+          <div class="wind-speed">--</div>
+          <div class="wind-direction">--</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- WAVE FORECAST -->
+    <div class="info-panel" style="margin: 20px;">
+      <div class="panel-title">Swell Forecast (Dominant) at Current Location</div>
+      <div class="wave-forecast-grid" id="wave-forecast-grid">
+        <div class="wave-forecast-item">
+          <div class="wave-time">Loading...</div>
+          <div class="wave-height">--</div>
+          <div class="wave-period">--</div>
+          <div class="wave-direction">--</div>
+        </div>
+      </div>
+    </div>
+
     <!-- WIND -->
     <div class="info-panel" id="wind-panel" style="margin: 20px;">
       <div class="panel-title">Wind</div>
       <div class="data-grid" id="wind-grid"></div>
+    </div>
+
+    <!-- ENVIRONMENT -->
+    <div class="info-panel" id="environment-panel" style="margin: 20px;">
+      <div class="panel-title">Environment</div>
+      <div class="data-grid" id="environment-grid"></div>
     </div>
 
     <!-- POWER -->
@@ -62,16 +112,25 @@
       <div class="data-grid" id="power-grid"></div>
     </div>
 
+    <!-- NOW PLAYING -->
+    <div class="info-panel" id="now-playing-panel" style="margin: 20px;">
+      <div class="panel-title">Now Playing</div>
+      <div id="now-playing-content" style="display: flex; align-items: center; gap: 20px; padding: 15px; background: var(--bg-secondary); border-radius: 8px; border: 1px solid var(--border-color);">
+        <div style="flex: 1;">
+          <div id="track-name" style="font-size: 1.2em; font-weight: bold; color: var(--text-primary); margin-bottom: 5px;">No track playing</div>
+          <div id="artist-album" style="color: var(--text-secondary); font-size: 0.9em;">No artist information</div>
+        </div>
+        <div id="track-info" style="flex: 1; text-align: right;">
+          <div id="playback-source" style="color: var(--text-secondary); font-size: 0.9em;">No source</div>
+          <div id="track-number" style="color: var(--text-secondary); font-size: 0.8em;">Track -- of --</div>
+        </div>
+      </div>
+    </div>
+
     <!-- VESSEL INFORMATION -->
     <div class="info-panel" id="vessel-panel" style="margin: 20px;">
       <div class="panel-title">Vessel Information</div>
       <div class="data-grid" id="vessel-grid"></div>
-    </div>
-
-    <!-- ENVIRONMENT -->
-    <div class="info-panel" id="environment-panel" style="margin: 20px;">
-      <div class="panel-title">Environment</div>
-      <div class="data-grid" id="environment-grid"></div>
     </div>
 
     <!-- INTERNET -->
@@ -92,71 +151,18 @@
       <div class="data-grid" id="tanks-grid"></div>
     </div>
 
-    <!-- NOW PLAYING SECTION -->
-    <div class="info-panel" id="now-playing-panel" style="margin: 20px;">
-      <div class="panel-title">Now Playing</div>
-      <div id="now-playing-content" style="display: flex; align-items: center; gap: 20px; padding: 15px; background: var(--bg-secondary); border-radius: 8px; border: 1px solid var(--border-color);">
-        <div style="flex: 1;">
-          <div id="track-name" style="font-size: 1.2em; font-weight: bold; color: var(--text-primary); margin-bottom: 5px;">No track playing</div>
-          <div id="artist-album" style="color: var(--text-secondary); font-size: 0.9em;">No artist information</div>
-        </div>
-        <div id="track-info" style="flex: 1; text-align: right;">
-          <div id="playback-source" style="color: var(--text-secondary); font-size: 0.9em;">No source</div>
-          <div id="track-number" style="color: var(--text-secondary); font-size: 0.8em;">Track -- of --</div>
-        </div>
-      </div>
-    </div>
-
-    <div class="info-panel" style="margin: 20px;">
-      <div id="tideHeader" class="panel-title" style="padding-top: 10px; margin-bottom: 0;"></div>
-      <canvas id="tideChart"></canvas>
-    </div>
-
-    <!-- WIND FORECAST SECTION -->
-    <div class="info-panel" style="margin: 20px;">
-      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">
-        <div id="windHeader" class="panel-title" style="flex: 1; margin-bottom: 0;">Wind Forecast at Current Location</div>
-        <select id="forecast-model" style="padding: 8px 12px; border-radius: 6px; border: 1px solid var(--border-color); background: var(--bg-secondary); color: var(--text-primary); font-size: 0.9em; cursor: pointer;">
-          <option value="wttr">wttr.in</option>
-          <option value="ecmwf">ECMWF</option>
-        </select>
-      </div>
-      <div class="wind-forecast-grid" id="wind-forecast-grid">
-        <div class="wind-forecast-item">
-          <div class="wind-time">Loading...</div>
-          <div class="wind-speed">--</div>
-          <div class="wind-direction">--</div>
-        </div>
-      </div>
-    </div>
-
-    <!-- WAVE FORECAST SECTION -->
-    <div class="info-panel" style="margin: 20px;">
-      <div class="panel-title">Swell Forecast (Dominant) at Current Location</div>
-      <div class="wave-forecast-grid" id="wave-forecast-grid">
-        <div class="wave-forecast-item">
-          <div class="wave-time">Loading...</div>
-          <div class="wave-height">--</div>
-          <div class="wave-period">--</div>
-          <div class="wave-direction">--</div>
-        </div>
-      </div>
-    </div>
-
-    <!-- POLAR PERFORMANCE SECTION -->
+    <!-- POLAR PERFORMANCE -->
     <div class="info-panel" style="margin: 20px;">
       <div class="panel-title">Polar Performance</div>
       <div class="polar-performance-grid" id="polar-performance-grid">
         <!-- Left Column: Performance Data -->
         <div style="display: flex; flex-direction: column; gap: 15px;">
-          <!-- Current Performance -->
           <div style="background: var(--bg-quaternary); padding: 15px; border-radius: 8px;">
             <div style="font-weight: bold; margin-bottom: 10px; color: var(--text-primary);">Current Performance</div>
             <div id="polar-performance" style="font-size: 0.9em;">
               <div>Loading polar data...</div>
             </div>
           </div>
-          <!-- VMG Analysis -->
           <div style="background: var(--bg-quaternary); padding: 15px; border-radius: 8px;">
             <div style="font-weight: bold; margin-bottom: 10px; color: var(--text-primary);">VMG Analysis</div>
             <div id="vmg-analysis" style="font-size: 0.9em;">


### PR DESCRIPTION
…reorder

- Status sentence shifts to past tense when data is stale (>6h): "Last seen at anchor in Sausalito, CA"
- Passage banner: set passage.from/to/departed in info.yaml to show a voyage context strip below the map (hidden when not set)
- WiFi-only crew tools (SignalK, Freeboard, Anchor Alarm) moved into a collapsed <details> element; AIS links remain visible
- Panel order reoriented for remote observers: Navigation → Tides → Wind forecast → Wave forecast → Wind → Environment → Power → Now Playing → Vessel info → Internet → Propulsion → Tanks → Polar

https://claude.ai/code/session_019MxzN4tHFW7aetUqeY2bB9