### PR TITLE
Forecast caching, anchor watch visuals, PWA manifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@
   <title id="page-title">Vessel Tracker</title>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <link rel="icon" href="/assets/favicon.ico" />
+  <link rel="manifest" href="manifest.json" />
+  <meta name="theme-color" content="#2c3e50" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="Mermug" />
+  <link rel="apple-touch-icon" href="data/vessel/logo.png" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3.0.1"></script>
   <link rel="stylesheet" href="assets/styles.css" />

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "S.V. Mermug Tracker",
+  "short_name": "Mermug",
+  "description": "Live vessel tracker — position, weather, and systems for S.V. Mermug.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait-primary",
+  "background_color": "#1a2332",
+  "theme_color": "#2c3e50",
+  "icons": [
+    {
+      "src": "data/vessel/logo.png",
+      "sizes": "any",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}


### PR DESCRIPTION
Forecast caching (localStorage, auto-expires):
- Tide: 3-hour TTL keyed by NOAA station + date; skips the NOAA API call on repeat loads within the same block of time
- Wind/Wave: 1-hour TTL keyed by rounded lat/lon + model; silently falls back to fetch if localStorage is unavailable

Anchor watch:
- Add ⚓ emoji marker at the anchor drop position (anchorMarker)
- Add dashed amber line from drop to vessel (anchorLine, rode visual)
- Swing-radius circle tooltip now shows current distance vs max radius ("Swing radius: 120 ft · Boat is 43 ft out")
- All three layers update on every poll and clear when anchor is weighed

PWA / installable:
- manifest.json with standalone display, vessel name, logo icon
- <link rel="manifest"> + theme-color meta added to <head>
- Apple-specific tags (apple-mobile-web-app-capable, status bar style, title, apple-touch-icon) for iOS "Add to Home Screen"

https://claude.ai/code/session_019MxzN4tHFW7aetUqeY2bB9