### PR TITLE
Right-justify forecast sidebar labels; double top logo size

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -101,7 +101,7 @@ body {
 }
 
 .status-hero__logo {
-  height: 48px;
+  height: 96px;
   width: auto;
   object-fit: contain;
   display: block;
@@ -858,7 +858,8 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: flex-start;
+  align-items: flex-end;
+  text-align: right;
   padding: 0 8px 0 10px;
   gap: 2px;
   background: var(--bg-quaternary);
@@ -971,7 +972,7 @@ body {
     padding: 16px;
   }
 
-  .status-hero__logo { height: 38px; }
+  .status-hero__logo { height: 76px; }
 
   #status-sentence { white-space: normal; }
 


### PR DESCRIPTION
Conditions row labels: align-items flex-end + text-align right so cr-name/cr-value sit flush against the divider border.

Status hero logo: 48px → 96px (76px on mobile), roughly 2×.

https://claude.ai/code/session_019MxzN4tHFW7aetUqeY2bB9