### PR TITLE
Fix map tiles disappearing on theme change; pin banner to dark orange

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -2911,9 +2911,10 @@ function updateDarkModeButton(theme) {
 }
 
 function updateChartsForTheme(theme) {
+  const isDark = isDarkTheme(theme);
+
   // Update tide chart
   if (tideChartInstance) {
-    const isDark = isDarkTheme(theme);
     tideChartInstance.options.scales.x.grid.color = isDark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.08)';
     tideChartInstance.options.scales.y.grid.color = isDark ? 'rgba(255, 255, 255, 0.2)' : 'rgba(0, 0, 0, 0.08)';
     tideChartInstance.options.scales.x.ticks.color = isDark ? '#ffffff' : '#2c3e50';

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -287,19 +287,14 @@ body {
   align-items: center;
   gap: 20px;
   padding: 20px 28px;
-  border-bottom: 1px solid var(--border-color);
-  background: var(--bg-secondary);
-  transition: background-color 0.3s ease, color 0.3s ease;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.18);
+  background: #b85010;
+  color: #ffffff;
 }
 
 #status-hero.stale {
-  background: #fff8f8;
-  color: #7a2020;
-}
-
-[data-theme="dark"] #status-hero.stale {
-  background: #1f1414;
-  color: #f0c0c0;
+  background: #8b2010;
+  color: #ffd0c0;
 }
 
 .status-hero__left {
@@ -319,7 +314,7 @@ body {
 #status-vessel {
   font-weight: 700;
   font-size: 1.3em;
-  color: var(--text-primary);
+  color: #ffffff;
   letter-spacing: -0.02em;
   white-space: nowrap;
   line-height: 1.2;
@@ -335,7 +330,7 @@ body {
 #status-sentence {
   font-size: 1.05em;
   font-weight: 500;
-  color: var(--text-primary);
+  color: #ffffff;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -344,7 +339,7 @@ body {
 
 #status-age {
   font-size: 0.75em;
-  color: var(--text-muted);
+  color: rgba(255, 255, 255, 0.7);
   font-weight: 400;
   letter-spacing: 0.01em;
 }


### PR DESCRIPTION
Map: isDark was declared inside the if (tideChartInstance) block so it was out of scope at the map tile section — causing a ReferenceError that silently dropped the addTo(map) call. Hoisted isDark to the top of updateChartsForTheme so it's available everywhere.

Banner: #status-hero pinned to constant #b85010 dark orange / white text so it no longer shifts with theme changes. status-vessel, status-sentence, and status-age text colors also fixed to white/ semi-transparent white to match.

https://claude.ai/code/session_019MxzN4tHFW7aetUqeY2bB9