### PR TITLE
Fix relative import error when running signalk_token_management.py directly

### DIFF
--- a/scripts/signalk_token_management.py
+++ b/scripts/signalk_token_management.py
@@ -14,7 +14,11 @@ import uuid
 import requests
 
 # Import utilities (used in multiple methods)
-from .utils import load_vessel_info, save_vessel_info
+# Support both direct invocation (python3 scripts/...) and module invocation (python -m scripts....)
+try:
+    from .utils import load_vessel_info, save_vessel_info
+except ImportError:
+    from utils import load_vessel_info, save_vessel_info
 
 
 class SignalKTokenRequester:
@@ -324,7 +328,7 @@ def main():
             else:
                 print(f"[ERROR] SignalK token issue: {message}")
                 print("\nTo create a token, run:")
-                print("  python3 scripts/signalk_token_management.py")
+                print("  make create-signalk-token")
                 print("\nOr run the vessel configuration wizard:")
                 print("  make config")
 


### PR DESCRIPTION
The script used `from .utils import ...` which only works when invoked as
a module (`python -m scripts.signalk_token_management`). Running it directly
with `python3 scripts/signalk_token_management.py` failed with:
  ImportError: attempted relative import with no known parent package

Added a try/except fallback so the import works in both invocation styles.
Also fixed the --check error message which suggested the broken direct
invocation; it now points to `make create-signalk-token` instead.

https://claude.ai/code/session_01GyciG33XDm99YwrjCpMVvV