### PR TITLE
Add empirical polar accumulation service and UI toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ data/telemetry/*.log
 data/telemetry/*.json.bak
 data/vessel/*.log
 data/vessel/*.json.bak
+# Polar accumulator: Pi-local state, never pushed (derived CSV is committed instead)
+data/vessel/polars_accumulated.json
 
 # Configuration files with sensitive data
 config.ini

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 .PHONY: check-bme280-service-status check-bno055-service-status check-mmc5603-service-status check-sgp30-service-status
 .PHONY: show-logs-website show-logs-bme280 show-logs-bno055 show-logs-mmc5603 show-logs-sgp30
 .PHONY: calibrate-mmc5603 calibrate-bno055 calibrate-sgp30
+.PHONY: install-polars-service uninstall-polars-service check-service-status-polars show-logs-polars run-polar-update
 
 # Default target
 .DEFAULT_GOAL := help
@@ -167,7 +168,7 @@ check-linux:
 # Default target
 help:
 	@echo "Installation and General Usage:"
-	@echo "  make install        - Install all services (website, sensors)"
+	@echo "  make install        - Install all services (website, polars, sensors)"
 	@echo "  make uninstall      - Uninstall all services (Linux only)"
 	@echo "  make status         - Reports all sensor and website statuses"
 	@echo "  make config        - Interactive vessel configuration wizard"
@@ -184,6 +185,7 @@ help:
 	@echo "  make pre-commit-install - Install pre-commit hooks (requires uv)"
 	@echo "  make lint          - Run ruff linter and auto-fix issues on all Python files"
 	@echo "  make run-website-update       - Run one website telemetry update now"
+	@echo "  make run-polar-update         - Run one polar accumulation sample now"
 	@echo "  make run-bme280        - Run BME280 sensor read and publish"
 	@echo "  make run-bno055        - Run BNO055 sensor read and publish"
 	@echo "  make run-mmc5603      - Run MMC5603 sensor read and publish"
@@ -196,16 +198,19 @@ help:
 	@echo ""
 	@echo "Service management:"
 	@echo "  make install-website-service    - Install website data updater service"
+	@echo "  make install-polars-service     - Install polar accumulation service (10s)"
 	@echo "  make install-all-sensor-services    - Install all individual sensor services"
 	@echo "  make install-bme280-service    - Install BME280 sensor service"
 	@echo "  make install-bno055-service    - Install BNO055 sensor service"
 	@echo "  make install-mmc5603-service   - Install MMC5603 sensor service"
 	@echo "  make install-sgp30-service     - Install SGP30 sensor service"
 	@echo "  make check-service-status-website - Check website service status"
+	@echo "  make check-service-status-polars  - Check polar accumulation service status"
 	@echo "  make check-service-status-all-sensors - Check all sensor service statuses"
 	@echo ""
 	@echo "Logs:"
 	@echo "  make show-logs-website             - Show website service logs"
+	@echo "  make show-logs-polars              - Show polar accumulation service logs"
 	@echo "  make show-logs-all-sensors       - Show all sensor service logs"
 	@echo "  make show-logs-bme280          - Show BME280 sensor logs"
 	@echo "  make show-logs-bno055          - Show BNO055 sensor logs"
@@ -235,10 +240,13 @@ install: check-linux check-signalk-token
 	@echo ""
 	@echo "This will install:"
 	@echo "  - Website data updater service"
+	@echo "  - Polar accumulation service"
 	@echo "  - Individual sensor services (BME280, BNO055, MMC5603, SGP30)"
 	@echo ""
 	@echo ""
 	@$(MAKE) install-website-service
+	@echo ""
+	@$(MAKE) install-polars-service
 	@echo ""
 	@$(MAKE) install-all-sensor-services
 	@echo ""
@@ -246,6 +254,7 @@ install: check-linux check-signalk-token
 	@echo ""
 	@echo "Service Summary:"
 	@echo "  - Website service: Updates telemetry data every 150 seconds"
+	@echo "  - Polars service: Accumulates polar performance data every 10 seconds"
 	@echo "  - Fast sensor service: Publishes basic sensor data every 10 seconds"
 	@echo "  - Slow sensor service: Publishes all sensor data every 240 seconds"
 	@echo ""
@@ -259,10 +268,13 @@ uninstall: check-linux
 	@echo ""
 	@echo "This will uninstall:"
 	@echo "  - Website data updater service"
+	@echo "  - Polar accumulation service"
 	@echo "  - Individual sensor services (BME280, BNO055, MMC5603, SGP30)"
 	@echo ""
 	@echo ""
 	@$(MAKE) uninstall-website-service
+	@echo ""
+	@$(MAKE) uninstall-polars-service
 	@echo ""
 	@$(MAKE) uninstall-all-sensor-services
 	@echo ""
@@ -276,6 +288,49 @@ install-website-service: check-linux check-signalk-token
 		exit 1; \
 	fi
 	$(call install-service,website,vesselwebsite,Vessel Tracker Data Updater,scripts.update_signalk_data,--interval 150,150)
+
+install-polars-service: check-linux
+	@if [ -z "$(UV_BIN)" ]; then \
+		echo "Error: 'uv' is not installed. Please install uv first."; \
+		echo "Visit: https://github.com/astral-sh/uv"; \
+		exit 1; \
+	fi
+	@echo "Installing polar accumulation service..."
+	@if [ -f "/etc/systemd/system/vesselpolars.service" ]; then \
+		echo "vesselpolars service already exists. Uninstalling first..."; \
+		sudo systemctl stop vesselpolars 2>/dev/null || true; \
+		sudo systemctl disable vesselpolars 2>/dev/null || true; \
+	fi
+	@sed -e "s|{{DESCRIPTION}}|Vessel Polar Performance Accumulator|g" \
+		-e "s|{{USER}}|$$(whoami)|g" \
+		-e "s|{{WORKING_DIRECTORY}}|$(CURDIR)|g" \
+		-e "s|{{EXEC_START}}|$(UV_BIN) run python -m scripts.update_polar_data --interval 10|g" \
+		-e "s|{{SIGNALK_URL}}|http://$(SENSOR_HOST):$(SENSOR_PORT)/signalk/v1/api/vessels/self|g" \
+		"$(CURDIR)/services/polars.service.tpl" | sudo tee /etc/systemd/system/vesselpolars.service > /dev/null
+	@echo "Reloading systemd..."
+	@sudo systemctl daemon-reload
+	@echo "Enabling and starting vesselpolars service..."
+	@sudo systemctl enable vesselpolars
+	@sudo systemctl start vesselpolars
+	@echo "vesselpolars service installed and started successfully!"
+
+uninstall-polars-service: check-linux
+	$(call uninstall-service,vesselpolars)
+
+check-service-status-polars: check-linux
+	$(call check-service-status,vesselpolars,polars)
+
+show-logs-polars: check-linux
+	$(call show-service-logs,vesselpolars)
+
+run-polar-update:
+	@if [ -z "$(UV_BIN)" ]; then \
+		echo "Error: 'uv' is not installed. Please install uv first."; \
+		echo "Visit: https://github.com/astral-sh/uv"; \
+		exit 1; \
+	fi
+	@echo "Running one polar accumulation sample..."
+	"$(UV_BIN)" run python -m scripts.update_polar_data --interval 0 --signalk-url "http://$(SENSOR_HOST):$(SENSOR_PORT)/signalk/v1/api/vessels/self"
 
 install-all-sensor-services: check-linux check-signalk-token
 	@if [ -z "$(UV_BIN)" ]; then \
@@ -385,6 +440,15 @@ status: check-linux
 		echo "Service: vesselwebsite"; \
 		sudo systemctl is-active vesselwebsite >/dev/null 2>&1 && echo "Status: ✓ Active" || echo "Status: ✗ Inactive"; \
 		sudo systemctl is-enabled vesselwebsite >/dev/null 2>&1 && echo "Enabled: ✓ Yes" || echo "Enabled: ✗ No"; \
+	else \
+		echo "Status: ✗ Not installed"; \
+	fi
+	@echo ""
+	@echo "--- Polar Accumulation Service Status ---"
+	@if [ -f "/etc/systemd/system/vesselpolars.service" ]; then \
+		echo "Service: vesselpolars"; \
+		sudo systemctl is-active vesselpolars >/dev/null 2>&1 && echo "Status: ✓ Active" || echo "Status: ✗ Inactive"; \
+		sudo systemctl is-enabled vesselpolars >/dev/null 2>&1 && echo "Enabled: ✓ Yes" || echo "Enabled: ✗ No"; \
 	else \
 		echo "Status: ✗ Not installed"; \
 	fi

--- a/assets/app.js
+++ b/assets/app.js
@@ -415,6 +415,7 @@ function getAllStations() {
 let tideChartInstance = null;
 let polarChartInstance = null;
 let polarData = null;
+let activePolarSource = 'estimated'; // 'estimated' | 'calculated'
 let currentEnv = null; // Global environment data
 let currentNav = null; // Global navigation data
 let currentPropulsion = null; // Global propulsion data
@@ -1775,9 +1776,9 @@ async function loadData() {
   }
 }
 
-async function loadPolarData() {
+async function loadPolarData(csvPath = 'data/vessel/polars.csv') {
   try {
-    const response = await fetch('data/vessel/polars.csv');
+    const response = await fetch(csvPath);
 
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
@@ -1805,6 +1806,48 @@ async function loadPolarData() {
       <div style="color: #e74c3c;">Error loading polar data: ${error.message}</div>
     `;
   }
+}
+
+async function initPolarToggle() {
+  const btn = document.getElementById('polar-source-toggle');
+  if (!btn) return;
+
+  // Check whether calculated polars exist and have any non-zero data.
+  let hasCalculated = false;
+  try {
+    const resp = await fetch('data/vessel/polars_calculated.csv');
+    if (resp.ok) {
+      const text = await resp.text();
+      hasCalculated = text.split('\n').slice(1).some(line => {
+        return line.split(';').slice(1).some(v => parseFloat(v) > 0);
+      });
+    }
+  } catch (_) { /* file not present yet */ }
+
+  if (!hasCalculated) return;
+
+  const updateBtn = () => {
+    if (activePolarSource === 'estimated') {
+      btn.textContent = 'Estimated';
+      btn.title = 'Showing ORC estimated polars — click to switch to your calculated polars';
+    } else {
+      btn.textContent = 'Calculated';
+      btn.title = 'Showing your calculated polars — click to switch to ORC estimated polars';
+    }
+  };
+
+  updateBtn();
+  btn.style.display = '';
+
+  btn.addEventListener('click', async () => {
+    activePolarSource = activePolarSource === 'estimated' ? 'calculated' : 'estimated';
+    const csvPath = activePolarSource === 'calculated'
+      ? 'data/vessel/polars_calculated.csv'
+      : 'data/vessel/polars.csv';
+    await loadPolarData(csvPath);
+    updateBtn();
+    updatePolarPerformance();
+  });
 }
 
 function getPolarSpeed(twa, tws) {
@@ -3053,6 +3096,7 @@ function updateChartsForTheme(theme) {
 
   initDarkMode();
   loadPolarData();
+  initPolarToggle();
   loadData();
 
   // Real-time SignalK updates removed; using static data only

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -543,6 +543,28 @@ body {
   letter-spacing: 0.08em;
   color: var(--text-muted);
   margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.polar-toggle-btn {
+  font-size: 0.75em;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 10px;
+  border: 1px solid var(--text-muted);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  text-transform: uppercase;
+  transition: background 0.15s, color 0.15s;
+}
+
+.polar-toggle-btn:hover {
+  background: var(--text-muted);
+  color: var(--bg-primary, #fff);
 }
 
 .polar-sub-body {

--- a/index.html
+++ b/index.html
@@ -264,7 +264,10 @@
           </div>
         </div>
         <div class="polar-sub-card">
-          <div class="polar-sub-title">Polar Chart</div>
+          <div class="polar-sub-title">
+            Polar Chart
+            <button id="polar-source-toggle" class="polar-toggle-btn" style="display:none;" title="Toggle between ORC estimated polars and your calculated polars"></button>
+          </div>
           <div class="polar-chart-container">
             <div id="polar-engine-indicator" class="polar-engine-indicator" style="display:none;"></div>
             <canvas id="polarChart"></canvas>

--- a/scripts/update_polar_data.py
+++ b/scripts/update_polar_data.py
@@ -1,0 +1,227 @@
+"""Accumulate polar performance data from SignalK and write polars_calculated.csv.
+
+Runs continuously at a configurable interval (default 10s). For each sample:
+  - Reads TWS, TWA, and STW/SOG from the SignalK API
+  - Folds TWA to 0-180° (port/starboard symmetry)
+  - Updates a max-speed-per-bin accumulator (constant size, never grows)
+  - Writes polars_calculated.csv in the same semicolon-delimited format as polars.csv
+
+The accumulator is persisted to polars_accumulated.json (gitignored) so it
+survives service restarts. The CSV is a derived view — it never grows beyond
+its fixed grid dimensions.
+"""
+
+import argparse
+import json
+import math
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import requests
+
+from .utils import get_project_root, load_vessel_info
+
+ACCUMULATOR_FILE = "data/vessel/polars_accumulated.json"
+POLAR_CSV_FILE = "data/vessel/polars_calculated.csv"
+
+# Output grid — same TWS columns as polars.csv for drop-in frontend compatibility.
+OUTPUT_TWS: list[int] = [4, 6, 8, 10, 12, 14, 16, 20, 24]
+OUTPUT_TWA: list[int] = [0, 52, 60, 75, 90, 110, 120, 135, 150]
+
+# Accumulator bin resolution
+TWA_BIN_SIZE = 5  # degrees
+TWS_BIN_SIZE = 2  # knots
+
+# Quality-filter thresholds
+MIN_TWS_KTS = 2.0
+MIN_STW_KTS = 0.5
+
+
+def _twa_bin(twa_deg: float) -> int:
+    """Fold TWA to 0–180° then snap to the nearest TWA_BIN_SIZE grid point."""
+    twa = abs(twa_deg) % 360
+    if twa > 180:
+        twa = 360 - twa
+    return max(0, min(180, round(twa / TWA_BIN_SIZE) * TWA_BIN_SIZE))
+
+
+def _tws_bin(tws_kts: float) -> int:
+    """Snap TWS to the nearest TWS_BIN_SIZE grid point, clamped to [2, 30]."""
+    return max(2, min(30, round(tws_kts / TWS_BIN_SIZE) * TWS_BIN_SIZE))
+
+
+def load_accumulator(path: Path) -> dict:
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return {"bins": {}, "observations": 0, "last_updated": None}
+
+
+def save_accumulator(acc: dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(acc, indent=2))
+
+
+def update_accumulator(acc: dict, twa_deg: float, tws_kts: float, stw_kts: float) -> bool:
+    """Update the max-speed bin; return True if any bin was improved."""
+    if tws_kts < MIN_TWS_KTS or stw_kts < MIN_STW_KTS:
+        return False
+    key = f"{_twa_bin(twa_deg)}_{_tws_bin(tws_kts)}"
+    improved = key not in acc["bins"] or stw_kts > acc["bins"][key]
+    if improved:
+        acc["bins"][key] = round(stw_kts, 3)
+    acc["observations"] = acc.get("observations", 0) + 1
+    acc["last_updated"] = datetime.now(UTC).isoformat()
+    return improved
+
+
+def _best_speed(acc: dict, twa_target: float, tws_target: float) -> float:
+    """Return the best observed speed near (twa_target, tws_target)."""
+    best = 0.0
+    twa_center = round(twa_target / TWA_BIN_SIZE) * TWA_BIN_SIZE
+    tws_center = round(tws_target / TWS_BIN_SIZE) * TWS_BIN_SIZE
+    for dtwa in range(-TWA_BIN_SIZE * 2, TWA_BIN_SIZE * 2 + 1, TWA_BIN_SIZE):
+        tw = max(0, min(180, twa_center + dtwa))
+        for dtws in range(-TWS_BIN_SIZE * 2, TWS_BIN_SIZE * 2 + 1, TWS_BIN_SIZE):
+            ts = max(2, min(30, tws_center + dtws))
+            val = acc["bins"].get(f"{tw}_{ts}", 0.0)
+            if val > best:
+                best = val
+    return best
+
+
+def write_polar_csv(acc: dict, path: Path) -> None:
+    """Write polars_calculated.csv as a drop-in replacement for polars.csv."""
+    lines = ["twa/tws;" + ";".join(str(t) for t in OUTPUT_TWS)]
+    for twa in OUTPUT_TWA:
+        row = [
+            f"{_best_speed(acc, float(twa), float(tws)):.2f}"
+            for tws in OUTPUT_TWS
+        ]
+        lines.append(f"{twa};" + ";".join(row))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def _get_value(node: dict, *path: str) -> float | None:
+    """Traverse a nested SignalK dict and return the leaf .value, or None."""
+    for key in path:
+        if not isinstance(node, dict):
+            return None
+        node = node.get(key)
+    if isinstance(node, dict):
+        v = node.get("value")
+    else:
+        v = node
+    return float(v) if isinstance(v, (int, float)) else None
+
+
+def fetch_polar_sample(signalk_url: str) -> tuple[float, float, float] | None:
+    """Return (twa_deg, tws_kts, stw_kts) from SignalK, or None if unavailable."""
+    try:
+        resp = requests.get(signalk_url, timeout=5)
+        resp.raise_for_status()
+        blob = resp.json()
+    except Exception as exc:
+        print(f"SignalK fetch error: {exc}")
+        return None
+
+    nav = blob.get("navigation", {})
+    wind = blob.get("environment", {}).get("wind", {})
+
+    tws_ms = _get_value(wind, "speedTrue") or _get_value(wind, "speedApparent")
+    if tws_ms is None:
+        return None
+
+    twa_rad = (
+        _get_value(wind, "angleTrueWater")
+        or _get_value(wind, "angleTrueGround")
+        or _get_value(wind, "angleApparent")
+    )
+    if twa_rad is None:
+        return None
+
+    stw_ms = _get_value(nav, "speedThroughWater") or _get_value(nav, "speedOverGround")
+    if stw_ms is None:
+        return None
+
+    return math.degrees(twa_rad), tws_ms * 1.94384, stw_ms * 1.94384
+
+
+def _load_signalk_url() -> str:
+    try:
+        vessel = load_vessel_info("data/vessel/info.yaml")
+        sk = vessel.get("signalk", {})
+        if sk.get("host") and sk.get("port"):
+            return f"{sk.get('protocol', 'http')}://{sk['host']}:{sk['port']}/signalk/v1/api/vessels/self"
+    except Exception:
+        pass
+    return "http://localhost:3000/signalk/v1/api/vessels/self"
+
+
+def parse_args() -> SimpleNamespace:
+    parser = argparse.ArgumentParser(
+        description="Accumulate polar performance data from SignalK"
+    )
+    parser.add_argument("--signalk-url", dest="signalk_url", default=_load_signalk_url())
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=10,
+        help="Sampling interval in seconds (0 = one-shot)",
+    )
+    parser.add_argument("--accumulator", default=ACCUMULATOR_FILE)
+    parser.add_argument("--output", default=POLAR_CSV_FILE)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = get_project_root()
+    acc_path = (
+        Path(args.accumulator)
+        if Path(args.accumulator).is_absolute()
+        else (root / args.accumulator).resolve()
+    )
+    csv_path = (
+        Path(args.output)
+        if Path(args.output).is_absolute()
+        else (root / args.output).resolve()
+    )
+
+    acc = load_accumulator(acc_path)
+    print(
+        f"Loaded accumulator: {acc.get('observations', 0)} observations, "
+        f"{len(acc.get('bins', {}))} bins populated"
+    )
+
+    while True:
+        sample = fetch_polar_sample(args.signalk_url)
+        if sample is not None:
+            twa_deg, tws_kts, stw_kts = sample
+            improved = update_accumulator(acc, twa_deg, tws_kts, stw_kts)
+            if improved:
+                save_accumulator(acc, acc_path)
+                write_polar_csv(acc, csv_path)
+                print(
+                    f"New max: TWA={_twa_bin(twa_deg)}° TWS={_tws_bin(tws_kts)}kts "
+                    f"→ {stw_kts:.2f}kts | {acc['observations']} total observations"
+                )
+            else:
+                print(
+                    f"Sample: TWA={twa_deg:.1f}° TWS={tws_kts:.1f}kts "
+                    f"STW={stw_kts:.2f}kts (no improvement)"
+                )
+
+        if args.interval == 0:
+            break
+        time.sleep(args.interval)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_signalk_data.py
+++ b/scripts/update_signalk_data.py
@@ -220,6 +220,10 @@ def git_commit_and_push(
     file_path: Path, amend: bool, no_push: bool, force_push: bool
 ) -> None:
     subprocess.run(["git", "add", "data/telemetry"], check=True)
+    # Include calculated polars in the same commit so the site gets updated curves.
+    polar_csv = get_project_root() / "data/vessel/polars_calculated.csv"
+    if polar_csv.exists():
+        subprocess.run(["git", "add", str(polar_csv)], check=True)
     commit_cmd = ["git", "commit", "-m", f"Auto update {datetime.now().isoformat()}"]
     if amend:
         commit_cmd.insert(2, "--amend")

--- a/services/polars.service.tpl
+++ b/services/polars.service.tpl
@@ -1,0 +1,17 @@
+[Unit]
+Description={{DESCRIPTION}}
+After=network.target
+
+[Service]
+Type=simple
+User={{USER}}
+WorkingDirectory={{WORKING_DIRECTORY}}
+Environment=SIGNALK_URL={{SIGNALK_URL}}
+ExecStart={{EXEC_START}}
+Restart=always
+RestartSec=15
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/test_update_polar_data.py
+++ b/tests/test_update_polar_data.py
@@ -1,0 +1,250 @@
+import math
+from unittest.mock import patch
+
+import pytest
+
+import scripts.update_polar_data as upd
+
+
+# --- _twa_bin ---
+
+def test_twa_bin_starboard():
+    assert upd._twa_bin(45.0) == 45
+
+def test_twa_bin_folds_port_tack():
+    # 270° = 90° on the port side
+    assert upd._twa_bin(270.0) == 90
+
+def test_twa_bin_folds_near_180():
+    assert upd._twa_bin(200.0) == 160  # 360 - 200 = 160
+
+def test_twa_bin_snaps_to_grid_down():
+    assert upd._twa_bin(92.0) == 90
+
+def test_twa_bin_snaps_to_grid_up():
+    assert upd._twa_bin(93.0) == 95
+
+def test_twa_bin_clamps_to_180():
+    assert upd._twa_bin(180.0) == 180
+
+def test_twa_bin_zero():
+    assert upd._twa_bin(0.0) == 0
+
+def test_twa_bin_negative_folds():
+    # Negative angles should fold the same as their positive mirror
+    assert upd._twa_bin(-45.0) == upd._twa_bin(45.0)
+
+
+# --- _tws_bin ---
+
+def test_tws_bin_snaps_to_even():
+    assert upd._tws_bin(9.0) == 8  # rounds to nearest 2
+
+def test_tws_bin_snaps_up():
+    assert upd._tws_bin(11.0) == 12  # rounds to nearest 2 (11 rounds to 12 for nearest even)
+
+def test_tws_bin_clamps_low():
+    assert upd._tws_bin(0.5) == 2
+
+def test_tws_bin_clamps_high():
+    assert upd._tws_bin(50.0) == 30
+
+def test_tws_bin_exact():
+    assert upd._tws_bin(10.0) == 10
+
+
+# --- update_accumulator ---
+
+def test_update_accumulator_records_new_bin():
+    acc = {"bins": {}, "observations": 0}
+    improved = upd.update_accumulator(acc, 90.0, 10.0, 5.5)
+    assert improved
+    assert acc["bins"]["90_10"] == 5.5
+    assert acc["observations"] == 1
+
+def test_update_accumulator_keeps_max():
+    acc = {"bins": {}, "observations": 0}
+    upd.update_accumulator(acc, 90.0, 10.0, 5.5)
+    improved = upd.update_accumulator(acc, 90.0, 10.0, 4.0)  # slower
+    assert not improved
+    assert acc["bins"]["90_10"] == 5.5
+
+def test_update_accumulator_replaces_with_new_max():
+    acc = {"bins": {}, "observations": 0}
+    upd.update_accumulator(acc, 90.0, 10.0, 5.5)
+    improved = upd.update_accumulator(acc, 90.0, 10.0, 7.0)  # faster
+    assert improved
+    assert acc["bins"]["90_10"] == 7.0
+
+def test_update_accumulator_filters_low_tws():
+    acc = {"bins": {}, "observations": 0}
+    improved = upd.update_accumulator(acc, 90.0, 1.0, 3.0)  # TWS below MIN_TWS_KTS
+    assert not improved
+    assert acc["bins"] == {}
+
+def test_update_accumulator_filters_low_stw():
+    acc = {"bins": {}, "observations": 0}
+    improved = upd.update_accumulator(acc, 90.0, 10.0, 0.2)  # STW below MIN_STW_KTS
+    assert not improved
+    assert acc["bins"] == {}
+
+def test_update_accumulator_increments_observations_even_without_improvement():
+    acc = {"bins": {}, "observations": 0}
+    upd.update_accumulator(acc, 90.0, 10.0, 5.5)
+    upd.update_accumulator(acc, 90.0, 10.0, 4.0)  # no improvement
+    assert acc["observations"] == 2
+
+def test_update_accumulator_folds_twa():
+    acc = {"bins": {}, "observations": 0}
+    # 270° should land in the same bin as 90°
+    upd.update_accumulator(acc, 90.0, 10.0, 5.0)
+    upd.update_accumulator(acc, 270.0, 10.0, 6.0)  # port tack, faster
+    assert acc["bins"]["90_10"] == 6.0
+
+def test_update_accumulator_sets_last_updated():
+    acc = {"bins": {}, "observations": 0}
+    upd.update_accumulator(acc, 90.0, 10.0, 5.5)
+    assert acc["last_updated"] is not None
+
+
+# --- load_accumulator / save_accumulator ---
+
+def test_accumulator_roundtrip(tmp_path):
+    path = tmp_path / "acc.json"
+    acc = {"bins": {"90_10": 7.2}, "observations": 42, "last_updated": "2026-01-01"}
+    upd.save_accumulator(acc, path)
+    loaded = upd.load_accumulator(path)
+    assert loaded["bins"]["90_10"] == 7.2
+    assert loaded["observations"] == 42
+
+def test_load_accumulator_returns_empty_when_missing(tmp_path):
+    acc = upd.load_accumulator(tmp_path / "nonexistent.json")
+    assert acc["bins"] == {}
+    assert acc["observations"] == 0
+
+def test_load_accumulator_handles_corrupt_file(tmp_path):
+    path = tmp_path / "corrupt.json"
+    path.write_text("not json{{{")
+    acc = upd.load_accumulator(path)
+    assert acc["bins"] == {}
+
+
+# --- write_polar_csv ---
+
+def test_write_polar_csv_header(tmp_path):
+    acc = {"bins": {}, "observations": 0}
+    csv = tmp_path / "polars_calculated.csv"
+    upd.write_polar_csv(acc, csv)
+    first_line = csv.read_text().split("\n")[0]
+    assert first_line == "twa/tws;4;6;8;10;12;14;16;20;24"
+
+def test_write_polar_csv_row_count(tmp_path):
+    acc = {"bins": {}, "observations": 0}
+    csv = tmp_path / "polars_calculated.csv"
+    upd.write_polar_csv(acc, csv)
+    data_lines = [l for l in csv.read_text().strip().split("\n") if l]
+    # 1 header + 9 TWA rows
+    assert len(data_lines) == 10
+
+def test_write_polar_csv_twa_rows(tmp_path):
+    acc = {"bins": {}, "observations": 0}
+    csv = tmp_path / "polars_calculated.csv"
+    upd.write_polar_csv(acc, csv)
+    lines = csv.read_text().strip().split("\n")
+    twas = [int(l.split(";")[0]) for l in lines[1:] if l]
+    assert twas == upd.OUTPUT_TWA
+
+def test_write_polar_csv_reflects_bin_data(tmp_path):
+    acc = {"bins": {"90_10": 7.5}, "observations": 1}
+    csv = tmp_path / "polars_calculated.csv"
+    upd.write_polar_csv(acc, csv)
+    # The 90° row should have a non-zero value near the 10-knot column
+    lines = csv.read_text().strip().split("\n")
+    row_90 = next(l for l in lines if l.startswith("90;"))
+    speeds = [float(v) for v in row_90.split(";")[1:]]
+    assert any(s > 0 for s in speeds)
+
+def test_write_polar_csv_all_zeros_when_no_data(tmp_path):
+    acc = {"bins": {}, "observations": 0}
+    csv = tmp_path / "polars_calculated.csv"
+    upd.write_polar_csv(acc, csv)
+    lines = csv.read_text().strip().split("\n")
+    for line in lines[1:]:
+        speeds = [float(v) for v in line.split(";")[1:]]
+        assert all(s == 0.0 for s in speeds)
+
+
+# --- fetch_polar_sample ---
+
+def _make_signalk_blob(tws_ms=5.14, twa_rad=math.radians(90), stw_ms=3.09):
+    return {
+        "navigation": {"speedThroughWater": {"value": stw_ms}},
+        "environment": {
+            "wind": {
+                "speedTrue": {"value": tws_ms},
+                "angleTrueWater": {"value": twa_rad},
+            }
+        },
+    }
+
+
+def _fake_requests(blob):
+    class FakeResp:
+        def raise_for_status(self): pass
+        def json(self): return blob
+
+    class FakeRequests:
+        @staticmethod
+        def get(url, timeout=5): return FakeResp()
+
+    return FakeRequests
+
+
+def test_fetch_polar_sample_returns_tuple():
+    with patch("scripts.update_polar_data.requests", _fake_requests(_make_signalk_blob())):
+        result = upd.fetch_polar_sample("http://fake")
+    assert result is not None
+    twa_deg, tws_kts, stw_kts = result
+    assert abs(twa_deg - 90.0) < 1.0
+    assert abs(tws_kts - 5.14 * 1.94384) < 0.1
+    assert abs(stw_kts - 3.09 * 1.94384) < 0.1
+
+def test_fetch_polar_sample_returns_none_on_missing_wind():
+    blob = {"navigation": {"speedThroughWater": {"value": 3.0}}}  # no wind
+    with patch("scripts.update_polar_data.requests", _fake_requests(blob)):
+        assert upd.fetch_polar_sample("http://fake") is None
+
+def test_fetch_polar_sample_returns_none_on_missing_speed():
+    blob = {
+        "environment": {
+            "wind": {
+                "speedTrue": {"value": 5.0},
+                "angleTrueWater": {"value": 1.57},
+            }
+        }
+    }
+    with patch("scripts.update_polar_data.requests", _fake_requests(blob)):
+        assert upd.fetch_polar_sample("http://fake") is None
+
+def test_fetch_polar_sample_falls_back_to_sog():
+    blob = {
+        "navigation": {"speedOverGround": {"value": 3.0}},  # STW absent, SOG present
+        "environment": {
+            "wind": {
+                "speedTrue": {"value": 5.0},
+                "angleTrueWater": {"value": 1.57},
+            }
+        },
+    }
+    with patch("scripts.update_polar_data.requests", _fake_requests(blob)):
+        result = upd.fetch_polar_sample("http://fake")
+    assert result is not None
+
+def test_fetch_polar_sample_returns_none_on_network_error():
+    class BrokenRequests:
+        @staticmethod
+        def get(url, timeout=5):
+            raise ConnectionError("no route to host")
+
+    with patch("scripts.update_polar_data.requests", BrokenRequests):
+        assert upd.fetch_polar_sample("http://fake") is None


### PR DESCRIPTION
- New scripts/update_polar_data.py: queries SignalK every 10s, bins
  (TWA, TWS) → max STW using a constant-size accumulator (≤540 cells),
  persists to polars_accumulated.json (gitignored) and derives
  data/vessel/polars_calculated.csv on every new high-water mark.

- New services/polars.service.tpl: minimal systemd template for the
  polar service (no git env vars needed).

- update_signalk_data.py: git add polars_calculated.csv alongside
  telemetry so calculated polars are pushed with each 150s update.

- Makefile: install-polars-service / uninstall-polars-service /
  check-service-status-polars / show-logs-polars / run-polar-update
  targets; polars service included in install/uninstall/status.

- index.html + app.js: toggle button in Polar Chart panel header;
  hidden until polars_calculated.csv exists with non-zero data, then
  lets the user flip between ORC estimated and their own polars.

- styles.css: .polar-toggle-btn pill styling.

- .gitignore: ignore polars_accumulated.json (Pi-local accumulator).

https://claude.ai/code/session_012bD9HKwKaj6syQrAwNQX91