### PR TITLE
Fix offline commit queue: proper git history instead of amend+force-push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,6 @@ define install-service
 			-e "s|{{RESTART_SEC}}|$(6)|g" \
 			-e "s|{{GIT_BRANCH}}|$(CURRENT_BRANCH)|g" \
 			-e "s|{{GIT_REMOTE}}|origin|g" \
-			-e "s|{{GIT_AMEND}}|false|g" \
-			-e "s|{{GIT_FORCE_PUSH}}|false|g" \
 			-e "s|{{SIGNALK_URL}}|http://$(SENSOR_HOST):$(SENSOR_PORT)/signalk/v1/api/vessels/self|g" \
 			-e "s|{{OUTPUT_FILE}}|data/telemetry/signalk_latest.json|g" \
 			"$(CURDIR)/services/systemd.service.tpl" | sudo tee /etc/systemd/system/$(2).service > /dev/null; \

--- a/Makefile
+++ b/Makefile
@@ -519,7 +519,7 @@ run-website-update:
 	fi
 	@echo "Running one website telemetry update..."
 	@echo "Fetching from SignalK and writing data..."; \
-	"$(UV_BIN)" run python -m scripts.update_signalk_data --no-reset --amend --force-push --signalk-url "http://$(SENSOR_HOST):$(SENSOR_PORT)/signalk/v1/api/vessels/self" --output data/telemetry/signalk_latest.json
+	"$(UV_BIN)" run python -m scripts.update_signalk_data --signalk-url "http://$(SENSOR_HOST):$(SENSOR_PORT)/signalk/v1/api/vessels/self" --output data/telemetry/signalk_latest.json
 
 # Run tests
 test: test-py test-js

--- a/scripts/update_signalk_data.py
+++ b/scripts/update_signalk_data.py
@@ -117,28 +117,10 @@ def parse_args() -> SimpleNamespace:
         help="Use HTTPS instead of HTTP for SignalK connection",
     )
     parser.add_argument(
-        "--no-reset",
-        dest="no_reset",
-        action="store_true",
-        default=os.getenv("NO_RESET", "false").lower() == "true",
-    )
-    parser.add_argument(
         "--no-push",
         dest="no_push",
         action="store_true",
         default=os.getenv("NO_PUSH", "false").lower() == "true",
-    )
-    parser.add_argument(
-        "--amend",
-        dest="amend",
-        action="store_true",
-        default=os.getenv("GIT_AMEND", "true").lower() == "true",
-    )
-    parser.add_argument(
-        "--force-push",
-        dest="force_push",
-        action="store_true",
-        default=os.getenv("GIT_FORCE_PUSH", "true").lower() == "true",
     )
     return parser.parse_args()
 
@@ -211,30 +193,30 @@ def filter_stale_data(
     return blob
 
 
-def git_reset(remote: str, branch: str) -> None:
-    subprocess.run(["git", "fetch", "--all"], check=True)
-    subprocess.run(["git", "reset", "--hard", f"{remote}/{branch}"], check=True)
-
-
-def git_commit_and_push(
-    file_path: Path, amend: bool, no_push: bool, force_push: bool
-) -> None:
+def git_commit_and_push(no_push: bool, remote: str, branch: str) -> None:
     subprocess.run(["git", "add", "data/telemetry"], check=True)
-    # Include calculated polars in the same commit so the site gets updated curves.
     polar_csv = get_project_root() / "data/vessel/polars_calculated.csv"
     if polar_csv.exists():
         subprocess.run(["git", "add", str(polar_csv)], check=True)
-    commit_cmd = ["git", "commit", "-m", f"Auto update {datetime.now().isoformat()}"]
-    if amend:
-        commit_cmd.insert(2, "--amend")
-    # allow empty to avoid failures when content is unchanged
-    commit_cmd.insert(2, "--allow-empty")
-    subprocess.run(commit_cmd, check=True)
-    if not no_push:
-        push_cmd = ["git", "push"]
-        if force_push:
-            push_cmd.append("--force")
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", f"Auto update {datetime.now().isoformat()}"],
+        check=True,
+    )
+    if no_push:
+        return
+    push_cmd = ["git", "push", remote, branch]
+    try:
         subprocess.run(push_cmd, check=True)
+    except subprocess.CalledProcessError:
+        # Push failed — fetch latest and rebase queued commits on top, then retry.
+        # If that also fails (offline or genuine conflict), defer and continue.
+        try:
+            subprocess.run(["git", "fetch", remote], check=True)
+            subprocess.run(["git", "rebase", f"{remote}/{branch}"], check=True)
+            subprocess.run(push_cmd, check=True)
+        except subprocess.CalledProcessError as e:
+            subprocess.run(["git", "rebase", "--abort"], check=False)
+            print(f"Push deferred (offline or merge conflict): {e}")
 
 
 def _parse_timestamp(value: Any) -> datetime | None:
@@ -489,10 +471,7 @@ def run_update(
     signalk_url: str,
     output_path: str,
     use_https: bool,
-    no_reset: bool,
-    amend: bool,
     no_push: bool,
-    force_push: bool,
 ) -> Path:
     # Modify SignalK URL if use_https is specified
     if use_https and signalk_url.startswith("http://"):
@@ -506,8 +485,6 @@ def run_update(
 
     # Ensure destination directory exists
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    if not no_reset:
-        git_reset(remote=remote, branch=branch)
     blob = fetch_blob(signalk_url=signalk_url)
 
     # Replace position with zone center in the blob if inside a privacy zone.
@@ -528,9 +505,7 @@ def run_update(
     output_file.write_text(json.dumps(blob, indent=2), encoding="utf-8")
     print(f"Wrote SignalK blob to {output_file}")
     update_position_cache(blob, output_file)
-    git_commit_and_push(
-        file_path=output_file, amend=amend, no_push=no_push, force_push=force_push
-    )
+    git_commit_and_push(no_push=no_push, remote=remote, branch=branch)
     return output_file
 
 
@@ -544,10 +519,7 @@ def main() -> int:
                 signalk_url=args.signalk_url,
                 output_path=args.output,
                 use_https=args.use_https,
-                no_reset=args.no_reset,
-                amend=args.amend,
                 no_push=args.no_push,
-                force_push=args.force_push,
             )
             if args.interval == 0:
                 break

--- a/scripts/update_signalk_data.py
+++ b/scripts/update_signalk_data.py
@@ -198,8 +198,11 @@ def git_commit_and_push(no_push: bool, remote: str, branch: str) -> None:
     polar_csv = get_project_root() / "data/vessel/polars_calculated.csv"
     if polar_csv.exists():
         subprocess.run(["git", "add", str(polar_csv)], check=True)
+    nothing_staged = subprocess.run(["git", "diff", "--cached", "--quiet"]).returncode == 0
+    if nothing_staged:
+        return
     subprocess.run(
-        ["git", "commit", "--allow-empty", "-m", f"Auto update {datetime.now().isoformat()}"],
+        ["git", "commit", "-m", f"Auto update {datetime.now().isoformat()}"],
         check=True,
     )
     if no_push:

--- a/services/systemd.service.tpl
+++ b/services/systemd.service.tpl
@@ -8,8 +8,6 @@ User={{USER}}
 WorkingDirectory={{WORKING_DIRECTORY}}
 Environment=GIT_BRANCH={{GIT_BRANCH}}
 Environment=GIT_REMOTE={{GIT_REMOTE}}
-Environment=GIT_AMEND={{GIT_AMEND}}
-Environment=GIT_FORCE_PUSH={{GIT_FORCE_PUSH}}
 Environment=SIGNALK_URL={{SIGNALK_URL}}
 Environment=OUTPUT_FILE={{OUTPUT_FILE}}
 ExecStart={{EXEC_START}}

--- a/tests/test_update_signalk_data.py
+++ b/tests/test_update_signalk_data.py
@@ -60,7 +60,6 @@ def test_filter_stale_data_keeps_recent_values():
 
 
 def test_run_on_dev_branch_writes_file_and_calls_git(tmp_path, test_branch):
-    # Fake requests module to avoid dependency and network
     class FakeResp:
         def raise_for_status(self):
             pass
@@ -73,7 +72,6 @@ def test_run_on_dev_branch_writes_file_and_calls_git(tmp_path, test_branch):
         def get(url):
             return FakeResp()
 
-    # Capture subprocess.run calls
     calls = []
 
     def fake_run(cmd, check=True, **kwargs):
@@ -84,7 +82,6 @@ def test_run_on_dev_branch_writes_file_and_calls_git(tmp_path, test_branch):
 
         return R()
 
-    # Patch both requests module and subprocess.run
     with (
         patch("scripts.update_signalk_data.requests", FakeRequests),
         patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
@@ -94,22 +91,17 @@ def test_run_on_dev_branch_writes_file_and_calls_git(tmp_path, test_branch):
         usd.run_update(
             branch=test_branch,
             remote="origin",
-            signalk_url="http://example",  # mocked
+            signalk_url="http://example",
             output_path=str(out),
             use_https=False,
-            no_reset=False,
-            amend=False,
             no_push=False,
-            force_push=False,
         )
 
         assert out.exists()
         assert json.loads(out.read_text()) == {"ok": True}
-        # Ensure reset targeted origin/_test_branch_tmp and commit without --amend --force
-        assert ["git", "fetch", "--all"] in calls
-        assert ["git", "reset", "--hard", f"origin/{test_branch}"] in calls
         assert any(cmd[:3] == ["git", "commit", "--allow-empty"] for cmd in calls)
-        assert ["git", "push"] in calls
+        assert any(cmd[:2] == ["git", "push"] for cmd in calls)
+        assert not any(cmd[:2] == ["git", "reset"] for cmd in calls)
 
 
 def test_https_conversion(tmp_path, test_branch):
@@ -125,7 +117,6 @@ def test_https_conversion(tmp_path, test_branch):
     class FakeRequests:
         @staticmethod
         def get(url):
-            # Verify the URL was converted to HTTPS
             assert url.startswith("https://")
             return FakeResp()
 
@@ -150,164 +141,12 @@ def test_https_conversion(tmp_path, test_branch):
             remote="origin",
             signalk_url="http://example.com:3000/api",
             output_path=str(out),
-            use_https=True,  # This should convert HTTP to HTTPS
-            no_reset=False,
-            amend=False,
+            use_https=True,
             no_push=False,
-            force_push=False,
         )
 
         assert out.exists()
         assert json.loads(out.read_text()) == {"data": "test"}
-
-
-def test_no_reset_mode(tmp_path, test_branch):
-    """Test that git reset is skipped when no_reset=True."""
-
-    class FakeResp:
-        def raise_for_status(self):
-            pass
-
-        def json(self):
-            return {"data": "test"}
-
-    class FakeRequests:
-        @staticmethod
-        def get(url):
-            return FakeResp()
-
-    calls = []
-
-    def fake_run(cmd, check=True, **kwargs):
-        calls.append(cmd)
-
-        class R:
-            returncode = 0
-
-        return R()
-
-    with (
-        patch("scripts.update_signalk_data.requests", FakeRequests),
-        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
-    ):
-        out = tmp_path / "signalk_latest.json"
-
-        usd.run_update(
-            branch=test_branch,
-            remote="origin",
-            signalk_url="http://example.com/api",
-            output_path=str(out),
-            use_https=False,
-            no_reset=True,  # This should skip git reset
-            amend=False,
-            no_push=False,
-            force_push=False,
-        )
-
-        assert out.exists()
-        # Verify git reset was not called
-        reset_calls = [cmd for cmd in calls if cmd[:2] == ["git", "reset"]]
-        assert len(reset_calls) == 0
-
-
-def test_amend_commit(tmp_path, test_branch):
-    """Test that --amend flag is used when amend=True."""
-
-    class FakeResp:
-        def raise_for_status(self):
-            pass
-
-        def json(self):
-            return {"data": "test"}
-
-    class FakeRequests:
-        @staticmethod
-        def get(url):
-            return FakeResp()
-
-    calls = []
-
-    def fake_run(cmd, check=True, **kwargs):
-        calls.append(cmd)
-
-        class R:
-            returncode = 0
-
-        return R()
-
-    with (
-        patch("scripts.update_signalk_data.requests", FakeRequests),
-        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
-    ):
-        out = tmp_path / "signalk_latest.json"
-
-        usd.run_update(
-            branch=test_branch,
-            remote="origin",
-            signalk_url="http://example.com/api",
-            output_path=str(out),
-            use_https=False,
-            no_reset=False,
-            amend=True,  # This should add --amend to commit
-            no_push=False,
-            force_push=False,
-        )
-
-        assert out.exists()
-        # Verify --amend was used in commit
-        commit_calls = [cmd for cmd in calls if cmd[:2] == ["git", "commit"]]
-        assert len(commit_calls) > 0
-        assert "--amend" in commit_calls[0]
-
-
-def test_force_push(tmp_path, test_branch):
-    """Test that --force flag is used when force_push=True."""
-
-    class FakeResp:
-        def raise_for_status(self):
-            pass
-
-        def json(self):
-            return {"data": "test"}
-
-    class FakeRequests:
-        @staticmethod
-        def get(url):
-            return FakeResp()
-
-    calls = []
-
-    def fake_run(cmd, check=True, **kwargs):
-        calls.append(cmd)
-
-        class R:
-            returncode = 0
-
-        return R()
-
-    with (
-        patch("scripts.update_signalk_data.requests", FakeRequests),
-        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
-    ):
-        out = tmp_path / "signalk_latest.json"
-
-        usd.run_update(
-            branch=test_branch,
-            remote="origin",
-            signalk_url="http://example.com/api",
-            output_path=str(out),
-            use_https=False,
-            no_reset=False,
-            amend=False,
-            no_push=False,
-            force_push=True,  # This should add --force to push
-        )
-
-        assert out.exists()
-        # Verify --force was used in push
-        push_calls = [cmd for cmd in calls if cmd[:2] == ["git", "push"]]
-        assert len(push_calls) > 0
-        assert "--force" in push_calls[0]
 
 
 def test_no_push_mode(tmp_path, test_branch):
@@ -347,16 +186,162 @@ def test_no_push_mode(tmp_path, test_branch):
             signalk_url="http://example.com/api",
             output_path=str(out),
             use_https=False,
-            no_reset=False,
-            amend=False,
-            no_push=True,  # This should skip git push
-            force_push=False,
+            no_push=True,
         )
 
         assert out.exists()
-        # Verify git push was not called
         push_calls = [cmd for cmd in calls if cmd[:2] == ["git", "push"]]
         assert len(push_calls) == 0
+
+
+def test_push_deferred_when_offline(tmp_path, test_branch):
+    """Push and fetch failures (offline) are caught; commit is preserved locally."""
+
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+    class FakeRequests:
+        @staticmethod
+        def get(url):
+            return FakeResp()
+
+    calls = []
+
+    def fake_run(cmd, check=True, **kwargs):
+        calls.append(cmd)
+        if cmd[:2] in (["git", "push"], ["git", "fetch"]):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    with (
+        patch("scripts.update_signalk_data.requests", FakeRequests),
+        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
+    ):
+        out = tmp_path / "signalk_latest.json"
+
+        # Should not raise even though all network ops fail
+        usd.run_update(
+            branch=test_branch,
+            remote="origin",
+            signalk_url="http://example",
+            output_path=str(out),
+            use_https=False,
+            no_push=False,
+        )
+
+        assert out.exists()
+        commit_calls = [cmd for cmd in calls if "commit" in cmd]
+        assert len(commit_calls) > 0
+        push_attempts = [cmd for cmd in calls if cmd[:2] == ["git", "push"]]
+        assert len(push_attempts) >= 1
+
+
+def test_push_rebases_on_diverged_remote(tmp_path, test_branch):
+    """On non-fast-forward push failure, script fetches, rebases, and retries push."""
+
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+    class FakeRequests:
+        @staticmethod
+        def get(url):
+            return FakeResp()
+
+    first_push_done = [False]
+    calls = []
+
+    def fake_run(cmd, check=True, **kwargs):
+        calls.append(cmd)
+        if cmd[:2] == ["git", "push"] and not first_push_done[0]:
+            first_push_done[0] = True
+            raise subprocess.CalledProcessError(1, cmd)
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    with (
+        patch("scripts.update_signalk_data.requests", FakeRequests),
+        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
+    ):
+        out = tmp_path / "signalk_latest.json"
+
+        usd.run_update(
+            branch=test_branch,
+            remote="origin",
+            signalk_url="http://example",
+            output_path=str(out),
+            use_https=False,
+            no_push=False,
+        )
+
+        assert out.exists()
+        assert any(cmd[:2] == ["git", "fetch"] for cmd in calls)
+        assert any(cmd[:2] == ["git", "rebase"] for cmd in calls)
+        push_calls = [cmd for cmd in calls if cmd[:2] == ["git", "push"]]
+        assert len(push_calls) == 2
+
+
+def test_push_aborts_rebase_on_conflict(tmp_path, test_branch):
+    """When rebase hits a conflict, abort is called and the script continues."""
+
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+    class FakeRequests:
+        @staticmethod
+        def get(url):
+            return FakeResp()
+
+    calls = []
+
+    def fake_run(cmd, check=True, **kwargs):
+        calls.append(cmd)
+        if cmd[:2] == ["git", "push"]:
+            raise subprocess.CalledProcessError(1, cmd)
+        if cmd[:2] == ["git", "rebase"] and "--abort" not in cmd:
+            raise subprocess.CalledProcessError(1, cmd)
+
+        class R:
+            returncode = 0
+
+        return R()
+
+    with (
+        patch("scripts.update_signalk_data.requests", FakeRequests),
+        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
+    ):
+        out = tmp_path / "signalk_latest.json"
+
+        usd.run_update(
+            branch=test_branch,
+            remote="origin",
+            signalk_url="http://example",
+            output_path=str(out),
+            use_https=False,
+            no_push=False,
+        )
+
+        assert out.exists()
+        abort_calls = [cmd for cmd in calls if cmd == ["git", "rebase", "--abort"]]
+        assert len(abort_calls) == 1
 
 
 def test_requests_error_handling(tmp_path, test_branch):
@@ -383,7 +368,6 @@ def test_requests_error_handling(tmp_path, test_branch):
     ):
         out = tmp_path / "signalk_latest.json"
 
-        # Should raise an exception when requests fails
         try:
             usd.run_update(
                 branch=test_branch,
@@ -391,15 +375,11 @@ def test_requests_error_handling(tmp_path, test_branch):
                 signalk_url="http://example.com/api",
                 output_path=str(out),
                 use_https=False,
-                no_reset=False,
-                amend=False,
                 no_push=False,
-                force_push=False,
             )
             raise Exception("Expected exception was not raised")
         except Exception as e:
             assert "Network error" in str(e)
-            # Verify no file was written
             assert not out.exists()
 
 
@@ -447,7 +427,6 @@ def test_integration_updates_test_branch(tmp_path, test_branch):
     run(["git", "fetch", "--all"], cwd=work)
     run(["git", "checkout", "-b", test_branch, f"origin/{test_branch}"], cwd=work)
 
-    # Fake requests module to avoid network
     class FakeResp:
         def raise_for_status(self):
             pass
@@ -460,11 +439,9 @@ def test_integration_updates_test_branch(tmp_path, test_branch):
         def get(url):
             return FakeResp()
 
-    # Patch the requests module with our fake implementation
     with patch("scripts.update_signalk_data.requests", FakeRequests):
         out = work / "signalk_latest.json"
 
-        # Change to the working directory before running the script
         original_cwd = os.getcwd()
         try:
             os.chdir(work)
@@ -474,17 +451,12 @@ def test_integration_updates_test_branch(tmp_path, test_branch):
                 signalk_url="http://example",
                 output_path=str(out),
                 use_https=False,
-                no_reset=False,
-                amend=False,
                 no_push=False,
-                force_push=False,
             )
         finally:
             os.chdir(original_cwd)
 
         assert out.exists()
-        # Ensure test_branch branch on origin has advanced (contains latest file content commit)
-        # Fetch the ref hash
         before_after = (
             subprocess.check_output(
                 ["git", "ls-remote", str(origin), f"refs/heads/{test_branch}"]

--- a/tests/test_update_signalk_data.py
+++ b/tests/test_update_signalk_data.py
@@ -78,7 +78,7 @@ def test_run_on_dev_branch_writes_file_and_calls_git(tmp_path, test_branch):
         calls.append(cmd)
 
         class R:
-            returncode = 0
+            returncode = 1 if cmd[:3] == ["git", "diff", "--cached"] else 0
 
         return R()
 
@@ -99,7 +99,7 @@ def test_run_on_dev_branch_writes_file_and_calls_git(tmp_path, test_branch):
 
         assert out.exists()
         assert json.loads(out.read_text()) == {"ok": True}
-        assert any(cmd[:3] == ["git", "commit", "--allow-empty"] for cmd in calls)
+        assert any(cmd[:2] == ["git", "commit"] for cmd in calls)
         assert any(cmd[:2] == ["git", "push"] for cmd in calls)
         assert not any(cmd[:2] == ["git", "reset"] for cmd in calls)
 
@@ -126,7 +126,7 @@ def test_https_conversion(tmp_path, test_branch):
         calls.append(cmd)
 
         class R:
-            returncode = 0
+            returncode = 1 if cmd[:3] == ["git", "diff", "--cached"] else 0
 
         return R()
 
@@ -170,7 +170,7 @@ def test_no_push_mode(tmp_path, test_branch):
         calls.append(cmd)
 
         class R:
-            returncode = 0
+            returncode = 1 if cmd[:3] == ["git", "diff", "--cached"] else 0
 
         return R()
 
@@ -192,6 +192,51 @@ def test_no_push_mode(tmp_path, test_branch):
         assert out.exists()
         push_calls = [cmd for cmd in calls if cmd[:2] == ["git", "push"]]
         assert len(push_calls) == 0
+
+
+def test_no_commit_when_data_unchanged(tmp_path, test_branch):
+    """No commit or push is made when staged diff is empty (data unchanged)."""
+
+    class FakeResp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"ok": True}
+
+    class FakeRequests:
+        @staticmethod
+        def get(url):
+            return FakeResp()
+
+    calls = []
+
+    def fake_run(cmd, check=True, **kwargs):
+        calls.append(cmd)
+
+        class R:
+            returncode = 0  # diff returns 0 → nothing staged
+
+        return R()
+
+    with (
+        patch("scripts.update_signalk_data.requests", FakeRequests),
+        patch("scripts.update_signalk_data.subprocess.run", side_effect=fake_run),
+    ):
+        out = tmp_path / "signalk_latest.json"
+
+        usd.run_update(
+            branch=test_branch,
+            remote="origin",
+            signalk_url="http://example",
+            output_path=str(out),
+            use_https=False,
+            no_push=False,
+        )
+
+        assert out.exists()
+        assert not any(cmd[:2] == ["git", "commit"] for cmd in calls)
+        assert not any(cmd[:2] == ["git", "push"] for cmd in calls)
 
 
 def test_push_deferred_when_offline(tmp_path, test_branch):
@@ -217,7 +262,7 @@ def test_push_deferred_when_offline(tmp_path, test_branch):
             raise subprocess.CalledProcessError(1, cmd)
 
         class R:
-            returncode = 0
+            returncode = 1 if cmd[:3] == ["git", "diff", "--cached"] else 0
 
         return R()
 
@@ -269,7 +314,7 @@ def test_push_rebases_on_diverged_remote(tmp_path, test_branch):
             raise subprocess.CalledProcessError(1, cmd)
 
         class R:
-            returncode = 0
+            returncode = 1 if cmd[:3] == ["git", "diff", "--cached"] else 0
 
         return R()
 
@@ -320,7 +365,7 @@ def test_push_aborts_rebase_on_conflict(tmp_path, test_branch):
             raise subprocess.CalledProcessError(1, cmd)
 
         class R:
-            returncode = 0
+            returncode = 1 if cmd[:3] == ["git", "diff", "--cached"] else 0
 
         return R()
 
@@ -358,7 +403,7 @@ def test_requests_error_handling(tmp_path, test_branch):
         calls.append(cmd)
 
         class R:
-            returncode = 0
+            returncode = 1 if cmd[:3] == ["git", "diff", "--cached"] else 0
 
         return R()
 


### PR DESCRIPTION
## Summary

- Replaces the `--amend` + `--force-push` pattern with real commits, so telemetry updates accumulate locally while Mermug is offline
- On push failure, automatically fetches, rebases queued commits onto the remote, and retries; if that also fails (offline or genuine conflict), defers gracefully and logs — the run continues without crashing
- Skips commit entirely when staged data is unchanged (avoids empty commits at anchor)
- Removes `--amend`, `--force-push`, and `--no-reset` flags; fixes stale Makefile one-shot target that still referenced them

## Test plan

- [x] 10 unit tests pass (`uv run pytest tests/test_update_signalk_data.py -v`)
- [x] Redeploy systemd service on the Pi (`make install-services`) to drop the now-ignored `GIT_AMEND`/`GIT_FORCE_PUSH` env vars from the running unit
- [ ] Verify commits accumulate locally while disconnected, then push cleanly on reconnect

https://claude.ai/code/session_01NYXcK5ZX3BT9hLHXJoPjgR