### PR TITLE
Always show track legend summary and history buttons

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -395,8 +395,6 @@ function renderTracks() {
   if (trackLegend) { trackLegend.remove(); trackLegend = null; }
   if (!days.length || !map) return;
 
-  const hasOlder = days.length > RECENT_TRACK_COUNT;
-
   trackLegend = L.control({ position: 'bottomright' });
   trackLegend.onAdd = () => {
     const div = L.DomUtil.create('div', 'track-legend');
@@ -418,20 +416,20 @@ function renderTracks() {
       </div>`;
     }
 
-    let historyHtml = '';
-    if (hasOlder) {
-      const histModes = [
-        { mode: '+5',  label: '+5',  count: 5 },
-        { mode: '+10', label: '+10', count: 10 },
-        { mode: 'all', label: 'All', count: Infinity },
-      ].filter(({ count }) => count === Infinity || olderCount > count);
-      const btns = histModes.map(({ mode, label }) =>
-        `<button class="track-hist-btn${trackHistoryMode === mode ? ' active' : ''}" data-mode="${mode}">${label}</button>`
-      ).join('');
-      historyHtml = `<div class="track-hist-row"><span class="track-hist-label">History:</span>${btns}</div>`;
-    }
+    const showing = recentDays.length + olderDays.length;
+    const summaryHtml = `<div class="track-legend-summary">Showing ${showing} of ${days.length} day${days.length === 1 ? '' : 's'}</div>`;
 
-    div.innerHTML = legendItems + olderSwatchHtml + historyHtml;
+    const histModes = [
+      { mode: '+5',  label: '+5',  count: 5 },
+      { mode: '+10', label: '+10', count: 10 },
+      { mode: 'all', label: 'All', count: Infinity },
+    ].filter(({ count }) => count === Infinity || olderCount > count);
+    const btns = histModes.map(({ mode, label }) =>
+      `<button class="track-hist-btn${trackHistoryMode === mode ? ' active' : ''}" data-mode="${mode}">${label}</button>`
+    ).join('');
+    const historyHtml = `<div class="track-hist-row"><span class="track-hist-label">History:</span>${btns}</div>`;
+
+    div.innerHTML = legendItems + olderSwatchHtml + summaryHtml + historyHtml;
 
     L.DomEvent.disableClickPropagation(div);
     L.DomEvent.disableScrollPropagation(div);

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -356,13 +356,20 @@ body {
   opacity: 0.65;
 }
 
+.track-legend-summary {
+  font-size: 0.82em;
+  opacity: 0.6;
+  margin-top: 6px;
+  padding-top: 5px;
+  border-top: 1px solid var(--border-color);
+  white-space: nowrap;
+}
+
 .track-hist-row {
   display: flex;
   align-items: center;
   gap: 4px;
-  margin-top: 6px;
-  padding-top: 5px;
-  border-top: 1px solid var(--border-color);
+  margin-top: 4px;
 }
 
 .track-hist-label {


### PR DESCRIPTION
Adds a "Showing X of Y days" summary line to the track legend so the
user can always tell how many days are loaded and how many are visible.
Removes the hasOlder guard so history buttons render even when all data
fits within the 10-day recent window, preventing a blank legend with no
context when fewer than 10 days of tracks are available.

https://claude.ai/code/session_01AaJUEjLJ1XqJxGxRoLcPHV