### PR TITLE
Add per-day GPX track files and long-term sailing history

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -26,7 +26,8 @@ let anchorMarker = null;   // ⚓ icon at anchor drop position
 let anchorLine = null;     // dashed line from anchor to vessel
 let trackLegend = null;    // Leaflet control for day-colour legend
 let trackHistoryMode = 'none'; // 'none' | '+5' | '+10' | 'all'
-let trackByDay = new Map();    // Cached track data keyed by YYYY-MM-DD
+let trackByDay = new Map();    // Cached track data keyed by YYYY-MM-DD (local)
+let tracksIndex = [];          // Metadata from tracks_index.json (all sailing days ever)
 let olderTrackLayer = null;    // Leaflet layer for older tracks shown in white
 let lat, lon; // Global variables for coordinates
 let vesselState = ''; // 'underway' | 'at anchor' | ''
@@ -326,6 +327,24 @@ function parsePositionPoint(point) {
   };
 }
 
+function _gpxLinkForDay(localDay) {
+  // Find the tracks_index entry whose start timestamp maps to this local day.
+  for (const track of tracksIndex) {
+    if (!track.file) continue;
+    const startLocal = track.start
+      ? (() => { const d = new Date(track.start); return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`; })()
+      : null;
+    if (track.date === localDay || startLocal === localDay) {
+      const vesselSlug = (vesselData?.name || 'vessel').replace(/[^a-z0-9]/gi, '-');
+      return {
+        url: `data/telemetry/${track.file}`,
+        filename: `${vesselSlug}-${track.date}.gpx`,
+      };
+    }
+  }
+  return null;
+}
+
 function renderTracks() {
   if (!map || !trackByDay.size) return;
 
@@ -401,9 +420,13 @@ function renderTracks() {
     const legendItems = recentDays.map((day, idx) => {
       const color = DAY_TRACK_COLORS[idx % DAY_TRACK_COLORS.length];
       const label = new Date(`${day}T12:00:00`).toLocaleDateString([], { month: 'short', day: 'numeric' });
+      const gpxLink = _gpxLinkForDay(day);
+      const dlBtn = gpxLink
+        ? `<a class="track-gpx-dl" href="${gpxLink.url}" download="${gpxLink.filename}" title="Download GPX">↓</a>`
+        : '';
       return `<div class="track-legend-item">
         <span class="track-legend-swatch" style="background:${color}"></span>
-        <span>${label}</span>
+        <span>${label}</span>${dlBtn}
       </div>`;
     }).join('');
 
@@ -480,9 +503,92 @@ async function loadTrack() {
 
     trackByDay = byDay;
     renderTracks();
+    // Load historical tracks (GPX files) without blocking the initial render.
+    loadHistoricalTracks();
   } catch (error) {
     console.warn('Unable to load track data:', error);
   }
+}
+
+function parseGpxText(gpxText) {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(gpxText, 'application/xml');
+  if (doc.querySelector('parsererror')) return [];
+  const points = [];
+  doc.querySelectorAll('trkpt').forEach((trkpt) => {
+    const lat = parseFloat(trkpt.getAttribute('lat'));
+    const lon = parseFloat(trkpt.getAttribute('lon'));
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return;
+    const timeEl = trkpt.querySelector('time');
+    const timestamp = timeEl ? timeEl.textContent.trim() : null;
+    const speedEl = trkpt.querySelector('speed');
+    const courseEl = trkpt.querySelector('course');
+    const speedMs = speedEl ? parseFloat(speedEl.textContent) : NaN;
+    const courseDeg = courseEl ? parseFloat(courseEl.textContent) : NaN;
+    points.push({
+      latitude: lat,
+      longitude: lon,
+      timestamp,
+      speedOverGround: Number.isFinite(speedMs) ? speedMs : NaN,
+      // Convert degrees → radians to match positions_index format
+      courseOverGroundTrue: Number.isFinite(courseDeg) ? courseDeg * Math.PI / 180 : NaN,
+    });
+  });
+  return points;
+}
+
+async function loadHistoricalTracks() {
+  try {
+    const resp = await fetch(`data/telemetry/tracks_index.json?ts=${Date.now()}`);
+    if (!resp.ok) return;
+    const data = await resp.json();
+    tracksIndex = Array.isArray(data) ? data : (data.tracks ?? []);
+  } catch (e) {
+    console.warn('Unable to load tracks index:', e);
+    return;
+  }
+
+  // Fetch all GPX files in parallel, skip days already covered by positions_index.
+  const covered = new Set(trackByDay.keys());
+  const toFetch = tracksIndex.filter((track) => {
+    // A track's UTC date might map to a different local day. Check both.
+    const utcDate = track.date;
+    const localDate = track.start
+      ? (() => { const d = new Date(track.start); return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`; })()
+      : null;
+    return !covered.has(utcDate) && !(localDate && covered.has(localDate));
+  });
+
+  if (!toFetch.length) return;
+
+  const results = await Promise.all(toFetch.map(async (track) => {
+    try {
+      const r = await fetch(`data/telemetry/${track.file}?ts=${Date.now()}`);
+      if (!r.ok) return null;
+      return { track, text: await r.text() };
+    } catch {
+      return null;
+    }
+  }));
+
+  let added = false;
+  for (const result of results) {
+    if (!result) continue;
+    const points = parseGpxText(result.text);
+    if (!points.length) continue;
+    // Group by local calendar day (same logic as loadTrack)
+    for (const p of points) {
+      if (!p.timestamp) continue;
+      const dt = new Date(p.timestamp);
+      const dayKey = `${dt.getFullYear()}-${String(dt.getMonth()+1).padStart(2,'0')}-${String(dt.getDate()).padStart(2,'0')}`;
+      if (!trackByDay.has(dayKey)) {
+        trackByDay.set(dayKey, []);
+        added = true;
+      }
+      trackByDay.get(dayKey).push(p);
+    }
+  }
+  if (added) renderTracks();
 }
 
 // Get all tide stations from loaded JSON data

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -401,6 +401,22 @@ body {
   color: #fff;
 }
 
+.track-gpx-dl {
+  margin-left: auto;
+  font-size: 0.7em;
+  opacity: 0.45;
+  text-decoration: none;
+  line-height: 1;
+  padding: 1px 3px;
+  border-radius: 2px;
+  color: inherit;
+}
+
+.track-gpx-dl:hover {
+  opacity: 1;
+  background: var(--bg-tertiary, rgba(255,255,255,0.1));
+}
+
 /* ─────────────────────────────────────────────────────────────────────────
    Sparklines
    ───────────────────────────────────────────────────────────────────────── */

--- a/data/telemetry/tracks/2026-02-28.gpx
+++ b/data/telemetry/tracks/2026-02-28.gpx
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-02-28</name>
+    <time>2026-02-28T23:02:37Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-02-28</name>
+    <trkseg>
+      <trkpt lat="37.783248" lon="-122.383846">
+        <time>2026-02-28T23:02:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.406</gpxtpx:speed>
+            <gpxtpx:course>29.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788940" lon="-122.382164">
+        <time>2026-02-28T23:05:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.911</gpxtpx:speed>
+            <gpxtpx:course>353.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.795598" lon="-122.383951">
+        <time>2026-02-28T23:07:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.814</gpxtpx:speed>
+            <gpxtpx:course>344.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.802277" lon="-122.385725">
+        <time>2026-02-28T23:10:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.909</gpxtpx:speed>
+            <gpxtpx:course>347.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.808485" lon="-122.387754">
+        <time>2026-02-28T23:12:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.804</gpxtpx:speed>
+            <gpxtpx:course>341.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.813263" lon="-122.390355">
+        <time>2026-02-28T23:15:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.846</gpxtpx:speed>
+            <gpxtpx:course>333.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814391" lon="-122.392039">
+        <time>2026-02-28T23:18:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.580</gpxtpx:speed>
+            <gpxtpx:course>287.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816289" lon="-122.395134">
+        <time>2026-02-28T23:20:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.550</gpxtpx:speed>
+            <gpxtpx:course>332.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820815" lon="-122.397379">
+        <time>2026-02-28T23:23:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.620</gpxtpx:speed>
+            <gpxtpx:course>336.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.825531" lon="-122.399721">
+        <time>2026-02-28T23:25:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.690</gpxtpx:speed>
+            <gpxtpx:course>339.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.830576" lon="-122.402012">
+        <time>2026-02-28T23:28:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.650</gpxtpx:speed>
+            <gpxtpx:course>340.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.835565" lon="-122.404007">
+        <time>2026-02-28T23:30:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.638</gpxtpx:speed>
+            <gpxtpx:course>342.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.839911" lon="-122.406319">
+        <time>2026-02-28T23:33:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.915</gpxtpx:speed>
+            <gpxtpx:course>339.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.843857" lon="-122.408137">
+        <time>2026-02-28T23:36:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.637</gpxtpx:speed>
+            <gpxtpx:course>311.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.846580" lon="-122.409844">
+        <time>2026-02-28T23:38:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.106</gpxtpx:speed>
+            <gpxtpx:course>352.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.849391" lon="-122.410422">
+        <time>2026-02-28T23:41:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.034</gpxtpx:speed>
+            <gpxtpx:course>354.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.851864" lon="-122.410656">
+        <time>2026-02-28T23:44:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.880</gpxtpx:speed>
+            <gpxtpx:course>352.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.854081" lon="-122.411104">
+        <time>2026-02-28T23:46:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.790</gpxtpx:speed>
+            <gpxtpx:course>339.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.856557" lon="-122.411656">
+        <time>2026-02-28T23:49:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.750</gpxtpx:speed>
+            <gpxtpx:course>349.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.858660" lon="-122.411987">
+        <time>2026-02-28T23:51:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.020</gpxtpx:speed>
+            <gpxtpx:course>341.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.860636" lon="-122.412079">
+        <time>2026-02-28T23:54:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.217</gpxtpx:speed>
+            <gpxtpx:course>350.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.862586" lon="-122.411822">
+        <time>2026-02-28T23:56:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.853</gpxtpx:speed>
+            <gpxtpx:course>26.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.863819" lon="-122.412160">
+        <time>2026-02-28T23:59:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.751</gpxtpx:speed>
+            <gpxtpx:course>324.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-03-01.gpx
+++ b/data/telemetry/tracks/2026-03-01.gpx
@@ -1,0 +1,539 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-03-01</name>
+    <time>2026-03-01T00:02:00Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-03-01</name>
+    <trkseg>
+      <trkpt lat="37.865524" lon="-122.413256">
+        <time>2026-03-01T00:02:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.093</gpxtpx:speed>
+            <gpxtpx:course>350.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.866816" lon="-122.413427">
+        <time>2026-03-01T00:04:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.475</gpxtpx:speed>
+            <gpxtpx:course>343.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.867116" lon="-122.413452">
+        <time>2026-03-01T00:07:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.899</gpxtpx:speed>
+            <gpxtpx:course>171.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.864416" lon="-122.412280">
+        <time>2026-03-01T00:09:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.606</gpxtpx:speed>
+            <gpxtpx:course>245.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.864160" lon="-122.416396">
+        <time>2026-03-01T00:12:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.720</gpxtpx:speed>
+            <gpxtpx:course>263.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.864042" lon="-122.419735">
+        <time>2026-03-01T00:14:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.812</gpxtpx:speed>
+            <gpxtpx:course>223.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.863943" lon="-122.420359">
+        <time>2026-03-01T00:17:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.527</gpxtpx:speed>
+            <gpxtpx:course>73.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.863884" lon="-122.420352">
+        <time>2026-03-01T00:20:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>89.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.863846" lon="-122.420346">
+        <time>2026-03-01T00:22:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.154</gpxtpx:speed>
+            <gpxtpx:course>89.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.863965" lon="-122.420460">
+        <time>2026-03-01T00:25:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.471</gpxtpx:speed>
+            <gpxtpx:course>336.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.863956" lon="-122.420671">
+        <time>2026-03-01T00:27:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.210</gpxtpx:speed>
+            <gpxtpx:course>326.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.864506" lon="-122.419664">
+        <time>2026-03-01T00:30:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.098</gpxtpx:speed>
+            <gpxtpx:course>40.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.867286" lon="-122.418616">
+        <time>2026-03-01T00:33:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.370</gpxtpx:speed>
+            <gpxtpx:course>347.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.870480" lon="-122.420083">
+        <time>2026-03-01T00:35:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.375</gpxtpx:speed>
+            <gpxtpx:course>312.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871689" lon="-122.424004">
+        <time>2026-03-01T00:38:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.824</gpxtpx:speed>
+            <gpxtpx:course>271.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871406" lon="-122.427069">
+        <time>2026-03-01T00:40:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.620</gpxtpx:speed>
+            <gpxtpx:course>294.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871378" lon="-122.426934">
+        <time>2026-03-01T00:43:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.150</gpxtpx:speed>
+            <gpxtpx:course>262.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871288" lon="-122.427025">
+        <time>2026-03-01T00:46:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.172</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871341" lon="-122.426964">
+        <time>2026-03-01T00:48:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.520</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871347" lon="-122.426992">
+        <time>2026-03-01T00:51:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.210</gpxtpx:speed>
+            <gpxtpx:course>229.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871367" lon="-122.426964">
+        <time>2026-03-01T00:53:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.110</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871333" lon="-122.426963">
+        <time>2026-03-01T00:56:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>229.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871356" lon="-122.426914">
+        <time>2026-03-01T00:59:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871335" lon="-122.426939">
+        <time>2026-03-01T01:01:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.094</gpxtpx:speed>
+            <gpxtpx:course>229.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871336" lon="-122.426943">
+        <time>2026-03-01T01:04:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.130</gpxtpx:speed>
+            <gpxtpx:course>229.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871285" lon="-122.427080">
+        <time>2026-03-01T01:06:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.170</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871325" lon="-122.427010">
+        <time>2026-03-01T01:09:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.140</gpxtpx:speed>
+            <gpxtpx:course>10.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871304" lon="-122.426992">
+        <time>2026-03-01T01:12:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.067</gpxtpx:speed>
+            <gpxtpx:course>24.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871332" lon="-122.426948">
+        <time>2026-03-01T01:14:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.160</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871319" lon="-122.426989">
+        <time>2026-03-01T01:17:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.150</gpxtpx:speed>
+            <gpxtpx:course>110.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871366" lon="-122.426947">
+        <time>2026-03-01T01:21:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.230</gpxtpx:speed>
+            <gpxtpx:course>110.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871353" lon="-122.426935">
+        <time>2026-03-01T01:23:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.130</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871336" lon="-122.426950">
+        <time>2026-03-01T01:26:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.136</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871345" lon="-122.426923">
+        <time>2026-03-01T01:28:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.170</gpxtpx:speed>
+            <gpxtpx:course>42.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871307" lon="-122.426978">
+        <time>2026-03-01T01:31:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.157</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871313" lon="-122.426900">
+        <time>2026-03-01T01:34:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.081</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871372" lon="-122.426953">
+        <time>2026-03-01T01:37:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.256</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871279" lon="-122.426936">
+        <time>2026-03-01T01:40:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.210</gpxtpx:speed>
+            <gpxtpx:course>42.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871345" lon="-122.426993">
+        <time>2026-03-01T01:42:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.531</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871412" lon="-122.426928">
+        <time>2026-03-01T01:45:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.200</gpxtpx:speed>
+            <gpxtpx:course>42.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871481" lon="-122.427402">
+        <time>2026-03-01T01:47:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.214</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871927" lon="-122.423128">
+        <time>2026-03-01T01:50:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.833</gpxtpx:speed>
+            <gpxtpx:course>97.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.870526" lon="-122.419968">
+        <time>2026-03-01T01:53:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.680</gpxtpx:speed>
+            <gpxtpx:course>161.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.868119" lon="-122.417987">
+        <time>2026-03-01T01:55:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.624</gpxtpx:speed>
+            <gpxtpx:course>151.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.862814" lon="-122.414833">
+        <time>2026-03-01T01:58:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.450</gpxtpx:speed>
+            <gpxtpx:course>151.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.857217" lon="-122.411664">
+        <time>2026-03-01T02:01:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.469</gpxtpx:speed>
+            <gpxtpx:course>162.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.851154" lon="-122.409142">
+        <time>2026-03-01T02:03:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.593</gpxtpx:speed>
+            <gpxtpx:course>165.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.845132" lon="-122.406870">
+        <time>2026-03-01T02:06:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.440</gpxtpx:speed>
+            <gpxtpx:course>159.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.839465" lon="-122.403611">
+        <time>2026-03-01T02:08:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.683</gpxtpx:speed>
+            <gpxtpx:course>162.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.833255" lon="-122.401206">
+        <time>2026-03-01T02:11:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.680</gpxtpx:speed>
+            <gpxtpx:course>161.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.827316" lon="-122.398989">
+        <time>2026-03-01T02:13:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.550</gpxtpx:speed>
+            <gpxtpx:course>162.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.821339" lon="-122.396579">
+        <time>2026-03-01T02:16:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.569</gpxtpx:speed>
+            <gpxtpx:course>162.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815570" lon="-122.394212">
+        <time>2026-03-01T02:19:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.197</gpxtpx:speed>
+            <gpxtpx:course>161.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.810013" lon="-122.391947">
+        <time>2026-03-01T02:21:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.950</gpxtpx:speed>
+            <gpxtpx:course>161.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.803867" lon="-122.388987">
+        <time>2026-03-01T02:24:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.106</gpxtpx:speed>
+            <gpxtpx:course>158.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.797031" lon="-122.385921">
+        <time>2026-03-01T02:26:46Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.090</gpxtpx:speed>
+            <gpxtpx:course>164.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.791728" lon="-122.383125">
+        <time>2026-03-01T02:29:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.702</gpxtpx:speed>
+            <gpxtpx:course>151.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788792" lon="-122.382721">
+        <time>2026-03-01T02:31:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.448</gpxtpx:speed>
+            <gpxtpx:course>173.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784180" lon="-122.382697">
+        <time>2026-03-01T02:34:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.985</gpxtpx:speed>
+            <gpxtpx:course>199.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781992" lon="-122.384646">
+        <time>2026-03-01T02:37:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.452</gpxtpx:speed>
+            <gpxtpx:course>181.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-03-05.gpx
+++ b/data/telemetry/tracks/2026-03-05.gpx
@@ -1,0 +1,345 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-03-05</name>
+    <time>2026-03-05T01:19:24Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-03-05</name>
+    <trkseg>
+      <trkpt lat="37.782380" lon="-122.384494">
+        <time>2026-03-05T01:19:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.070</gpxtpx:speed>
+            <gpxtpx:course>33.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785801" lon="-122.382590">
+        <time>2026-03-05T01:21:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.940</gpxtpx:speed>
+            <gpxtpx:course>18.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.790569" lon="-122.379953">
+        <time>2026-03-05T01:24:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.177</gpxtpx:speed>
+            <gpxtpx:course>11.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.792470" lon="-122.381280">
+        <time>2026-03-05T01:27:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.720</gpxtpx:speed>
+            <gpxtpx:course>318.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.794372" lon="-122.382295">
+        <time>2026-03-05T01:29:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.910</gpxtpx:speed>
+            <gpxtpx:course>322.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.797007" lon="-122.383050">
+        <time>2026-03-05T01:32:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.925</gpxtpx:speed>
+            <gpxtpx:course>1.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.800310" lon="-122.383030">
+        <time>2026-03-05T01:34:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.486</gpxtpx:speed>
+            <gpxtpx:course>4.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805484" lon="-122.384787">
+        <time>2026-03-05T01:37:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.767</gpxtpx:speed>
+            <gpxtpx:course>352.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.811430" lon="-122.384953">
+        <time>2026-03-05T01:39:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.250</gpxtpx:speed>
+            <gpxtpx:course>9.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816570" lon="-122.383449">
+        <time>2026-03-05T01:42:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.870</gpxtpx:speed>
+            <gpxtpx:course>21.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818261" lon="-122.384145">
+        <time>2026-03-05T01:45:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.870</gpxtpx:speed>
+            <gpxtpx:course>201.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815777" lon="-122.386061">
+        <time>2026-03-05T01:47:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.010</gpxtpx:speed>
+            <gpxtpx:course>219.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815287" lon="-122.388457">
+        <time>2026-03-05T01:50:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.130</gpxtpx:speed>
+            <gpxtpx:course>339.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816658" lon="-122.388088">
+        <time>2026-03-05T01:52:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.930</gpxtpx:speed>
+            <gpxtpx:course>5.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817858" lon="-122.387325">
+        <time>2026-03-05T01:55:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.967</gpxtpx:speed>
+            <gpxtpx:course>26.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819124" lon="-122.386514">
+        <time>2026-03-05T01:57:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.128</gpxtpx:speed>
+            <gpxtpx:course>32.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820729" lon="-122.385851">
+        <time>2026-03-05T02:00:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.240</gpxtpx:speed>
+            <gpxtpx:course>359.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818633" lon="-122.387264">
+        <time>2026-03-05T02:02:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.630</gpxtpx:speed>
+            <gpxtpx:course>198.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814023" lon="-122.388922">
+        <time>2026-03-05T02:05:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.400</gpxtpx:speed>
+            <gpxtpx:course>197.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.810195" lon="-122.392225">
+        <time>2026-03-05T02:08:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.560</gpxtpx:speed>
+            <gpxtpx:course>211.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806488" lon="-122.395189">
+        <time>2026-03-05T02:10:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.433</gpxtpx:speed>
+            <gpxtpx:course>174.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806117" lon="-122.392942">
+        <time>2026-03-05T02:13:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.271</gpxtpx:speed>
+            <gpxtpx:course>89.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805844" lon="-122.390284">
+        <time>2026-03-05T02:15:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.421</gpxtpx:speed>
+            <gpxtpx:course>100.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805660" lon="-122.387725">
+        <time>2026-03-05T02:18:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.327</gpxtpx:speed>
+            <gpxtpx:course>104.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805248" lon="-122.385445">
+        <time>2026-03-05T02:20:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.845</gpxtpx:speed>
+            <gpxtpx:course>109.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804137" lon="-122.382355">
+        <time>2026-03-05T02:23:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.892</gpxtpx:speed>
+            <gpxtpx:course>125.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.802926" lon="-122.379595">
+        <time>2026-03-05T02:26:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.725</gpxtpx:speed>
+            <gpxtpx:course>119.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.801547" lon="-122.377680">
+        <time>2026-03-05T02:28:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.644</gpxtpx:speed>
+            <gpxtpx:course>135.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.799832" lon="-122.375685">
+        <time>2026-03-05T02:31:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.130</gpxtpx:speed>
+            <gpxtpx:course>149.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.797245" lon="-122.374037">
+        <time>2026-03-05T02:33:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.628</gpxtpx:speed>
+            <gpxtpx:course>190.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.794667" lon="-122.376431">
+        <time>2026-03-05T02:36:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.260</gpxtpx:speed>
+            <gpxtpx:course>217.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.791451" lon="-122.379382">
+        <time>2026-03-05T02:38:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.817</gpxtpx:speed>
+            <gpxtpx:course>201.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788040" lon="-122.380981">
+        <time>2026-03-05T02:41:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.062</gpxtpx:speed>
+            <gpxtpx:course>204.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788213" lon="-122.381072">
+        <time>2026-03-05T02:43:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.880</gpxtpx:speed>
+            <gpxtpx:course>343.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788764" lon="-122.379749">
+        <time>2026-03-05T02:46:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.927</gpxtpx:speed>
+            <gpxtpx:course>63.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788376" lon="-122.379390">
+        <time>2026-03-05T02:49:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.010</gpxtpx:speed>
+            <gpxtpx:course>209.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783881" lon="-122.382734">
+        <time>2026-03-05T02:51:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.072</gpxtpx:speed>
+            <gpxtpx:course>212.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-03-08.gpx
+++ b/data/telemetry/tracks/2026-03-08.gpx
@@ -1,0 +1,776 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-03-08</name>
+    <time>2026-03-08T19:44:59Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-03-08</name>
+    <trkseg>
+      <trkpt lat="37.823626" lon="-122.400153">
+        <time>2026-03-08T19:44:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.406</gpxtpx:speed>
+            <gpxtpx:course>305.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.826056" lon="-122.404078">
+        <time>2026-03-08T19:47:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.930</gpxtpx:speed>
+            <gpxtpx:course>302.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.828872" lon="-122.408522">
+        <time>2026-03-08T19:50:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.460</gpxtpx:speed>
+            <gpxtpx:course>312.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.832460" lon="-122.412121">
+        <time>2026-03-08T19:52:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.517</gpxtpx:speed>
+            <gpxtpx:course>317.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.835472" lon="-122.416436">
+        <time>2026-03-08T19:55:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.970</gpxtpx:speed>
+            <gpxtpx:course>304.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.838057" lon="-122.420883">
+        <time>2026-03-08T19:57:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.844</gpxtpx:speed>
+            <gpxtpx:course>312.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.841028" lon="-122.425358">
+        <time>2026-03-08T20:00:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.252</gpxtpx:speed>
+            <gpxtpx:course>302.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.843268" lon="-122.428893">
+        <time>2026-03-08T20:03:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.848</gpxtpx:speed>
+            <gpxtpx:course>177.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.839461" lon="-122.428156">
+        <time>2026-03-08T20:05:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.110</gpxtpx:speed>
+            <gpxtpx:course>188.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.835698" lon="-122.428466">
+        <time>2026-03-08T20:08:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.197</gpxtpx:speed>
+            <gpxtpx:course>187.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.831463" lon="-122.429349">
+        <time>2026-03-08T20:10:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.490</gpxtpx:speed>
+            <gpxtpx:course>189.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.826575" lon="-122.429523">
+        <time>2026-03-08T20:13:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.280</gpxtpx:speed>
+            <gpxtpx:course>175.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.821910" lon="-122.429410">
+        <time>2026-03-08T20:15:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.398</gpxtpx:speed>
+            <gpxtpx:course>177.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817692" lon="-122.429570">
+        <time>2026-03-08T20:18:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.660</gpxtpx:speed>
+            <gpxtpx:course>186.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814261" lon="-122.430202">
+        <time>2026-03-08T20:21:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.810</gpxtpx:speed>
+            <gpxtpx:course>192.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.810525" lon="-122.432859">
+        <time>2026-03-08T20:23:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.054</gpxtpx:speed>
+            <gpxtpx:course>214.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809976" lon="-122.434445">
+        <time>2026-03-08T20:26:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.405</gpxtpx:speed>
+            <gpxtpx:course>250.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.808172" lon="-122.432864">
+        <time>2026-03-08T20:28:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.750</gpxtpx:speed>
+            <gpxtpx:course>159.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806364" lon="-122.432518">
+        <time>2026-03-08T20:31:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.540</gpxtpx:speed>
+            <gpxtpx:course>171.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806230" lon="-122.432458">
+        <time>2026-03-08T20:33:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>165.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806220" lon="-122.432461">
+        <time>2026-03-08T20:36:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.010</gpxtpx:speed>
+            <gpxtpx:course>165.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806219" lon="-122.432440">
+        <time>2026-03-08T20:39:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>165.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806216" lon="-122.432460">
+        <time>2026-03-08T20:41:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>165.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806226" lon="-122.432472">
+        <time>2026-03-08T20:44:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.039</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.807245" lon="-122.432731">
+        <time>2026-03-08T20:46:46Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.543</gpxtpx:speed>
+            <gpxtpx:course>351.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809193" lon="-122.433636">
+        <time>2026-03-08T20:49:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.143</gpxtpx:speed>
+            <gpxtpx:course>281.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809272" lon="-122.434086">
+        <time>2026-03-08T20:51:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.230</gpxtpx:speed>
+            <gpxtpx:course>347.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.811819" lon="-122.435429">
+        <time>2026-03-08T20:54:30Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.590</gpxtpx:speed>
+            <gpxtpx:course>325.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815118" lon="-122.438772">
+        <time>2026-03-08T20:57:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.400</gpxtpx:speed>
+            <gpxtpx:course>320.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818551" lon="-122.442532">
+        <time>2026-03-08T20:59:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.166</gpxtpx:speed>
+            <gpxtpx:course>312.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820354" lon="-122.446617">
+        <time>2026-03-08T21:02:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.507</gpxtpx:speed>
+            <gpxtpx:course>296.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.822441" lon="-122.451398">
+        <time>2026-03-08T21:04:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.160</gpxtpx:speed>
+            <gpxtpx:course>297.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.824764" lon="-122.456537">
+        <time>2026-03-08T21:07:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.343</gpxtpx:speed>
+            <gpxtpx:course>306.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.827263" lon="-122.461198">
+        <time>2026-03-08T21:09:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.320</gpxtpx:speed>
+            <gpxtpx:course>298.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.829344" lon="-122.465795">
+        <time>2026-03-08T21:12:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.101</gpxtpx:speed>
+            <gpxtpx:course>139.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.826279" lon="-122.464301">
+        <time>2026-03-08T21:15:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.500</gpxtpx:speed>
+            <gpxtpx:course>155.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.822087" lon="-122.462510">
+        <time>2026-03-08T21:17:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.450</gpxtpx:speed>
+            <gpxtpx:course>159.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817520" lon="-122.461948">
+        <time>2026-03-08T21:20:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.346</gpxtpx:speed>
+            <gpxtpx:course>194.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817931" lon="-122.465637">
+        <time>2026-03-08T21:22:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.840</gpxtpx:speed>
+            <gpxtpx:course>308.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820789" lon="-122.470124">
+        <time>2026-03-08T21:25:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.270</gpxtpx:speed>
+            <gpxtpx:course>308.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.822744" lon="-122.473656">
+        <time>2026-03-08T21:27:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.940</gpxtpx:speed>
+            <gpxtpx:course>306.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.823410" lon="-122.476612">
+        <time>2026-03-08T21:30:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.780</gpxtpx:speed>
+            <gpxtpx:course>176.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820352" lon="-122.476499">
+        <time>2026-03-08T21:33:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.704</gpxtpx:speed>
+            <gpxtpx:course>184.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817951" lon="-122.476198">
+        <time>2026-03-08T21:35:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.760</gpxtpx:speed>
+            <gpxtpx:course>167.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818621" lon="-122.477321">
+        <time>2026-03-08T21:38:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.686</gpxtpx:speed>
+            <gpxtpx:course>317.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.821760" lon="-122.480747">
+        <time>2026-03-08T21:40:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.854</gpxtpx:speed>
+            <gpxtpx:course>325.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.823003" lon="-122.482952">
+        <time>2026-03-08T21:43:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.812</gpxtpx:speed>
+            <gpxtpx:course>172.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820155" lon="-122.482292">
+        <time>2026-03-08T21:46:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.144</gpxtpx:speed>
+            <gpxtpx:course>175.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817286" lon="-122.481977">
+        <time>2026-03-08T21:48:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.695</gpxtpx:speed>
+            <gpxtpx:course>164.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814872" lon="-122.481504">
+        <time>2026-03-08T21:51:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.733</gpxtpx:speed>
+            <gpxtpx:course>172.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.812729" lon="-122.482090">
+        <time>2026-03-08T21:53:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.450</gpxtpx:speed>
+            <gpxtpx:course>204.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.810941" lon="-122.482982">
+        <time>2026-03-08T21:56:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.430</gpxtpx:speed>
+            <gpxtpx:course>208.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.808961" lon="-122.484365">
+        <time>2026-03-08T21:58:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.879</gpxtpx:speed>
+            <gpxtpx:course>214.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806795" lon="-122.485878">
+        <time>2026-03-08T22:01:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.830</gpxtpx:speed>
+            <gpxtpx:course>207.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805723" lon="-122.487254">
+        <time>2026-03-08T22:03:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.791</gpxtpx:speed>
+            <gpxtpx:course>308.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809131" lon="-122.488199">
+        <time>2026-03-08T22:06:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.746</gpxtpx:speed>
+            <gpxtpx:course>357.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.812797" lon="-122.487638">
+        <time>2026-03-08T22:09:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.515</gpxtpx:speed>
+            <gpxtpx:course>14.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815694" lon="-122.484752">
+        <time>2026-03-08T22:11:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.506</gpxtpx:speed>
+            <gpxtpx:course>52.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817452" lon="-122.480379">
+        <time>2026-03-08T22:14:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.000</gpxtpx:speed>
+            <gpxtpx:course>59.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819200" lon="-122.475597">
+        <time>2026-03-08T22:16:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.190</gpxtpx:speed>
+            <gpxtpx:course>72.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820526" lon="-122.469765">
+        <time>2026-03-08T22:19:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.862</gpxtpx:speed>
+            <gpxtpx:course>69.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.822294" lon="-122.463695">
+        <time>2026-03-08T22:21:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.580</gpxtpx:speed>
+            <gpxtpx:course>68.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.823023" lon="-122.456803">
+        <time>2026-03-08T22:24:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.967</gpxtpx:speed>
+            <gpxtpx:course>80.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.824004" lon="-122.450304">
+        <time>2026-03-08T22:27:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.384</gpxtpx:speed>
+            <gpxtpx:course>80.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.825142" lon="-122.444972">
+        <time>2026-03-08T22:29:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.976</gpxtpx:speed>
+            <gpxtpx:course>77.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.826300" lon="-122.439408">
+        <time>2026-03-08T22:32:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.478</gpxtpx:speed>
+            <gpxtpx:course>75.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.826018" lon="-122.433284">
+        <time>2026-03-08T22:34:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.058</gpxtpx:speed>
+            <gpxtpx:course>117.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.823158" lon="-122.427439">
+        <time>2026-03-08T22:37:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.070</gpxtpx:speed>
+            <gpxtpx:course>128.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820107" lon="-122.421688">
+        <time>2026-03-08T22:40:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.667</gpxtpx:speed>
+            <gpxtpx:course>115.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817653" lon="-122.416090">
+        <time>2026-03-08T22:42:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.803</gpxtpx:speed>
+            <gpxtpx:course>117.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815070" lon="-122.410733">
+        <time>2026-03-08T22:45:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.870</gpxtpx:speed>
+            <gpxtpx:course>130.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.812380" lon="-122.405899">
+        <time>2026-03-08T22:47:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.930</gpxtpx:speed>
+            <gpxtpx:course>121.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.810631" lon="-122.401828">
+        <time>2026-03-08T22:50:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.440</gpxtpx:speed>
+            <gpxtpx:course>118.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.808935" lon="-122.398477">
+        <time>2026-03-08T22:52:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.420</gpxtpx:speed>
+            <gpxtpx:course>128.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806408" lon="-122.395608">
+        <time>2026-03-08T22:55:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.190</gpxtpx:speed>
+            <gpxtpx:course>136.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804455" lon="-122.392906">
+        <time>2026-03-08T22:58:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.820</gpxtpx:speed>
+            <gpxtpx:course>121.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.802304" lon="-122.389087">
+        <time>2026-03-08T23:00:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.261</gpxtpx:speed>
+            <gpxtpx:course>130.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.799917" lon="-122.385024">
+        <time>2026-03-08T23:03:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.450</gpxtpx:speed>
+            <gpxtpx:course>123.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.798012" lon="-122.381814">
+        <time>2026-03-08T23:05:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.110</gpxtpx:speed>
+            <gpxtpx:course>131.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.795718" lon="-122.378767">
+        <time>2026-03-08T23:08:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.120</gpxtpx:speed>
+            <gpxtpx:course>132.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.793757" lon="-122.378412">
+        <time>2026-03-08T23:10:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.083</gpxtpx:speed>
+            <gpxtpx:course>232.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.792821" lon="-122.379391">
+        <time>2026-03-08T23:13:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.729</gpxtpx:speed>
+            <gpxtpx:course>192.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788789" lon="-122.380315">
+        <time>2026-03-08T23:15:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.950</gpxtpx:speed>
+            <gpxtpx:course>189.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785434" lon="-122.381863">
+        <time>2026-03-08T23:18:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.710</gpxtpx:speed>
+            <gpxtpx:course>204.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782314" lon="-122.384644">
+        <time>2026-03-08T23:21:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.968</gpxtpx:speed>
+            <gpxtpx:course>206.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-03-09.gpx
+++ b/data/telemetry/tracks/2026-03-09.gpx
@@ -1,0 +1,317 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-03-09</name>
+    <time>2026-03-09T14:12:32Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-03-09</name>
+    <trkseg>
+      <trkpt lat="37.782440" lon="-122.384423">
+        <time>2026-03-09T14:12:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.223</gpxtpx:speed>
+            <gpxtpx:course>37.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.787827" lon="-122.381975">
+        <time>2026-03-09T14:15:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.002</gpxtpx:speed>
+            <gpxtpx:course>352.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.794451" lon="-122.383469">
+        <time>2026-03-09T14:17:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.879</gpxtpx:speed>
+            <gpxtpx:course>348.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.801071" lon="-122.385298">
+        <time>2026-03-09T14:20:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.000</gpxtpx:speed>
+            <gpxtpx:course>349.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.807655" lon="-122.387361">
+        <time>2026-03-09T14:22:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.750</gpxtpx:speed>
+            <gpxtpx:course>338.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814163" lon="-122.389936">
+        <time>2026-03-09T14:25:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.946</gpxtpx:speed>
+            <gpxtpx:course>343.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820889" lon="-122.392477">
+        <time>2026-03-09T14:28:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.030</gpxtpx:speed>
+            <gpxtpx:course>344.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.827668" lon="-122.394888">
+        <time>2026-03-09T14:30:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.990</gpxtpx:speed>
+            <gpxtpx:course>345.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.834304" lon="-122.396950">
+        <time>2026-03-09T14:33:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.752</gpxtpx:speed>
+            <gpxtpx:course>342.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.840779" lon="-122.399250">
+        <time>2026-03-09T14:35:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.746</gpxtpx:speed>
+            <gpxtpx:course>342.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.846749" lon="-122.401075">
+        <time>2026-03-09T14:38:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.805</gpxtpx:speed>
+            <gpxtpx:course>346.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.851700" lon="-122.402609">
+        <time>2026-03-09T14:41:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.490</gpxtpx:speed>
+            <gpxtpx:course>345.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.856669" lon="-122.404248">
+        <time>2026-03-09T14:43:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.630</gpxtpx:speed>
+            <gpxtpx:course>343.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.861811" lon="-122.405246">
+        <time>2026-03-09T14:46:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.640</gpxtpx:speed>
+            <gpxtpx:course>4.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.867028" lon="-122.404742">
+        <time>2026-03-09T14:48:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.726</gpxtpx:speed>
+            <gpxtpx:course>5.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.872134" lon="-122.404283">
+        <time>2026-03-09T14:51:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.580</gpxtpx:speed>
+            <gpxtpx:course>7.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.876963" lon="-122.403442">
+        <time>2026-03-09T14:53:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.257</gpxtpx:speed>
+            <gpxtpx:course>8.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.881419" lon="-122.402512">
+        <time>2026-03-09T14:56:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.250</gpxtpx:speed>
+            <gpxtpx:course>5.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.885900" lon="-122.401132">
+        <time>2026-03-09T14:59:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.324</gpxtpx:speed>
+            <gpxtpx:course>14.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.890369" lon="-122.399618">
+        <time>2026-03-09T15:01:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.396</gpxtpx:speed>
+            <gpxtpx:course>15.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.894875" lon="-122.398053">
+        <time>2026-03-09T15:04:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.480</gpxtpx:speed>
+            <gpxtpx:course>18.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.899448" lon="-122.396505">
+        <time>2026-03-09T15:06:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.386</gpxtpx:speed>
+            <gpxtpx:course>13.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.903780" lon="-122.394021">
+        <time>2026-03-09T15:09:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.520</gpxtpx:speed>
+            <gpxtpx:course>34.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.904897" lon="-122.387833">
+        <time>2026-03-09T15:11:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.598</gpxtpx:speed>
+            <gpxtpx:course>73.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.904100" lon="-122.381355">
+        <time>2026-03-09T15:14:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.775</gpxtpx:speed>
+            <gpxtpx:course>106.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.903524" lon="-122.374734">
+        <time>2026-03-09T15:17:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.840</gpxtpx:speed>
+            <gpxtpx:course>102.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.903075" lon="-122.368111">
+        <time>2026-03-09T15:19:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.780</gpxtpx:speed>
+            <gpxtpx:course>76.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.905496" lon="-122.362800">
+        <time>2026-03-09T15:22:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.800</gpxtpx:speed>
+            <gpxtpx:course>1.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.910541" lon="-122.363095">
+        <time>2026-03-09T15:24:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.585</gpxtpx:speed>
+            <gpxtpx:course>351.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.915412" lon="-122.364047">
+        <time>2026-03-09T15:27:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.510</gpxtpx:speed>
+            <gpxtpx:course>345.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.919483" lon="-122.367417">
+        <time>2026-03-09T15:30:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.675</gpxtpx:speed>
+            <gpxtpx:course>308.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.921949" lon="-122.371431">
+        <time>2026-03-09T15:32:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.189</gpxtpx:speed>
+            <gpxtpx:course>300.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.922829" lon="-122.372810">
+        <time>2026-03-09T15:35:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.083</gpxtpx:speed>
+            <gpxtpx:course>352.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.923097" lon="-122.372746">
+        <time>2026-03-09T15:37:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.041</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-03-11.gpx
+++ b/data/telemetry/tracks/2026-03-11.gpx
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-03-11</name>
+    <time>2026-03-11T22:38:06Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-03-11</name>
+    <trkseg>
+      <trkpt lat="37.923099" lon="-122.372762">
+        <time>2026-03-11T22:38:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.070</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.922006" lon="-122.371788">
+        <time>2026-03-11T22:40:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.850</gpxtpx:speed>
+            <gpxtpx:course>138.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.919327" lon="-122.367665">
+        <time>2026-03-11T22:43:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.189</gpxtpx:speed>
+            <gpxtpx:course>126.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.915924" lon="-122.364344">
+        <time>2026-03-11T22:45:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.266</gpxtpx:speed>
+            <gpxtpx:course>164.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.911550" lon="-122.362957">
+        <time>2026-03-11T22:48:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.220</gpxtpx:speed>
+            <gpxtpx:course>168.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.907076" lon="-122.362056">
+        <time>2026-03-11T22:51:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.254</gpxtpx:speed>
+            <gpxtpx:course>174.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.904032" lon="-122.365044">
+        <time>2026-03-11T22:53:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.506</gpxtpx:speed>
+            <gpxtpx:course>259.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.904040" lon="-122.371529">
+        <time>2026-03-11T22:56:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.459</gpxtpx:speed>
+            <gpxtpx:course>277.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.904695" lon="-122.377257">
+        <time>2026-03-11T22:58:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.273</gpxtpx:speed>
+            <gpxtpx:course>281.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.905239" lon="-122.383180">
+        <time>2026-03-11T23:01:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.368</gpxtpx:speed>
+            <gpxtpx:course>276.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.906050" lon="-122.389006">
+        <time>2026-03-11T23:04:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.280</gpxtpx:speed>
+            <gpxtpx:course>279.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.906304" lon="-122.394844">
+        <time>2026-03-11T23:06:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.440</gpxtpx:speed>
+            <gpxtpx:course>265.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.904465" lon="-122.399256">
+        <time>2026-03-11T23:09:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.306</gpxtpx:speed>
+            <gpxtpx:course>184.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.899806" lon="-122.399787">
+        <time>2026-03-11T23:11:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.614</gpxtpx:speed>
+            <gpxtpx:course>183.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.894512" lon="-122.400020">
+        <time>2026-03-11T23:14:30Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.804</gpxtpx:speed>
+            <gpxtpx:course>182.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.889080" lon="-122.399791">
+        <time>2026-03-11T23:17:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.061</gpxtpx:speed>
+            <gpxtpx:course>174.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.883654" lon="-122.400834">
+        <time>2026-03-11T23:19:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.030</gpxtpx:speed>
+            <gpxtpx:course>189.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.878028" lon="-122.402348">
+        <time>2026-03-11T23:22:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.131</gpxtpx:speed>
+            <gpxtpx:course>194.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.872288" lon="-122.404081">
+        <time>2026-03-11T23:24:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.290</gpxtpx:speed>
+            <gpxtpx:course>192.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.866550" lon="-122.406027">
+        <time>2026-03-11T23:27:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.207</gpxtpx:speed>
+            <gpxtpx:course>195.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.863467" lon="-122.407223">
+        <time>2026-03-11T23:29:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.780</gpxtpx:speed>
+            <gpxtpx:course>203.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.860643" lon="-122.406613">
+        <time>2026-03-11T23:32:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.750</gpxtpx:speed>
+            <gpxtpx:course>174.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.855340" lon="-122.406558">
+        <time>2026-03-11T23:35:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.884</gpxtpx:speed>
+            <gpxtpx:course>187.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.849961" lon="-122.406644">
+        <time>2026-03-11T23:37:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.178</gpxtpx:speed>
+            <gpxtpx:course>166.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.844572" lon="-122.404352">
+        <time>2026-03-11T23:40:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.249</gpxtpx:speed>
+            <gpxtpx:course>159.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.839152" lon="-122.401854">
+        <time>2026-03-11T23:42:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.180</gpxtpx:speed>
+            <gpxtpx:course>158.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.833492" lon="-122.399447">
+        <time>2026-03-11T23:45:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.610</gpxtpx:speed>
+            <gpxtpx:course>165.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.827445" lon="-122.397050">
+        <time>2026-03-11T23:48:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.623</gpxtpx:speed>
+            <gpxtpx:course>160.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.821526" lon="-122.394414">
+        <time>2026-03-11T23:50:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.610</gpxtpx:speed>
+            <gpxtpx:course>166.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815667" lon="-122.391999">
+        <time>2026-03-11T23:53:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.299</gpxtpx:speed>
+            <gpxtpx:course>159.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809917" lon="-122.389320">
+        <time>2026-03-11T23:55:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.225</gpxtpx:speed>
+            <gpxtpx:course>157.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804493" lon="-122.387068">
+        <time>2026-03-11T23:58:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.586</gpxtpx:speed>
+            <gpxtpx:course>162.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-03-12.gpx
+++ b/data/telemetry/tracks/2026-03-12.gpx
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-03-12</name>
+    <time>2026-03-12T00:00:58Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-03-12</name>
+    <trkseg>
+      <trkpt lat="37.798952" lon="-122.385073">
+        <time>2026-03-12T00:00:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.859</gpxtpx:speed>
+            <gpxtpx:course>163.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.794117" lon="-122.383257">
+        <time>2026-03-12T00:03:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.015</gpxtpx:speed>
+            <gpxtpx:course>167.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789379" lon="-122.381449">
+        <time>2026-03-12T00:06:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.319</gpxtpx:speed>
+            <gpxtpx:course>164.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.786256" lon="-122.380536">
+        <time>2026-03-12T00:08:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.230</gpxtpx:speed>
+            <gpxtpx:course>191.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783545" lon="-122.382336">
+        <time>2026-03-12T00:11:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.420</gpxtpx:speed>
+            <gpxtpx:course>213.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782395" lon="-122.384031">
+        <time>2026-03-12T00:13:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.590</gpxtpx:speed>
+            <gpxtpx:course>263.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783603" lon="-122.382010">
+        <time>2026-03-12T00:29:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.195</gpxtpx:speed>
+            <gpxtpx:course>65.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783888" lon="-122.377409">
+        <time>2026-03-12T00:31:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.050</gpxtpx:speed>
+            <gpxtpx:course>266.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783859" lon="-122.378618">
+        <time>2026-03-12T00:34:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.090</gpxtpx:speed>
+            <gpxtpx:course>349.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.787593" lon="-122.380631">
+        <time>2026-03-12T00:37:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.940</gpxtpx:speed>
+            <gpxtpx:course>343.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.791390" lon="-122.382241">
+        <time>2026-03-12T00:39:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.199</gpxtpx:speed>
+            <gpxtpx:course>343.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.795219" lon="-122.384263">
+        <time>2026-03-12T00:42:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.338</gpxtpx:speed>
+            <gpxtpx:course>340.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.799680" lon="-122.385788">
+        <time>2026-03-12T00:44:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.650</gpxtpx:speed>
+            <gpxtpx:course>354.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804398" lon="-122.386560">
+        <time>2026-03-12T00:47:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.450</gpxtpx:speed>
+            <gpxtpx:course>347.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809091" lon="-122.387736">
+        <time>2026-03-12T00:49:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.480</gpxtpx:speed>
+            <gpxtpx:course>339.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804561" lon="-122.386182">
+        <time>2026-03-12T00:52:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.786</gpxtpx:speed>
+            <gpxtpx:course>153.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.798898" lon="-122.384000">
+        <time>2026-03-12T00:55:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.003</gpxtpx:speed>
+            <gpxtpx:course>169.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.793423" lon="-122.382736">
+        <time>2026-03-12T00:57:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.962</gpxtpx:speed>
+            <gpxtpx:course>156.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789039" lon="-122.381189">
+        <time>2026-03-12T01:00:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.716</gpxtpx:speed>
+            <gpxtpx:course>169.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783332" lon="-122.379474">
+        <time>2026-03-12T01:02:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.525</gpxtpx:speed>
+            <gpxtpx:course>182.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.780828" lon="-122.381032">
+        <time>2026-03-12T01:05:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.530</gpxtpx:speed>
+            <gpxtpx:course>305.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782255" lon="-122.384602">
+        <time>2026-03-12T01:08:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.650</gpxtpx:speed>
+            <gpxtpx:course>211.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-03-14.gpx
+++ b/data/telemetry/tracks/2026-03-14.gpx
@@ -1,0 +1,1062 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-03-14</name>
+    <time>2026-03-14T18:57:39Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-03-14</name>
+    <trkseg>
+      <trkpt lat="37.782734" lon="-122.383525">
+        <time>2026-03-14T18:57:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.960</gpxtpx:speed>
+            <gpxtpx:course>66.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783481" lon="-122.381675">
+        <time>2026-03-14T19:00:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.650</gpxtpx:speed>
+            <gpxtpx:course>72.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784985" lon="-122.380618">
+        <time>2026-03-14T19:02:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.694</gpxtpx:speed>
+            <gpxtpx:course>16.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788075" lon="-122.380601">
+        <time>2026-03-14T19:05:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.310</gpxtpx:speed>
+            <gpxtpx:course>352.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789330" lon="-122.380573">
+        <time>2026-03-14T19:08:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.350</gpxtpx:speed>
+            <gpxtpx:course>31.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789947" lon="-122.380127">
+        <time>2026-03-14T19:10:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.495</gpxtpx:speed>
+            <gpxtpx:course>38.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.790426" lon="-122.379668">
+        <time>2026-03-14T19:13:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.391</gpxtpx:speed>
+            <gpxtpx:course>33.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.790057" lon="-122.378703">
+        <time>2026-03-14T19:15:46Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.294</gpxtpx:speed>
+            <gpxtpx:course>125.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788305" lon="-122.376830">
+        <time>2026-03-14T19:18:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.365</gpxtpx:speed>
+            <gpxtpx:course>142.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785559" lon="-122.374382">
+        <time>2026-03-14T19:20:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.600</gpxtpx:speed>
+            <gpxtpx:course>171.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782517" lon="-122.372533">
+        <time>2026-03-14T19:23:30Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.430</gpxtpx:speed>
+            <gpxtpx:course>130.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.780778" lon="-122.371282">
+        <time>2026-03-14T19:26:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.610</gpxtpx:speed>
+            <gpxtpx:course>178.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781192" lon="-122.370884">
+        <time>2026-03-14T19:28:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.815</gpxtpx:speed>
+            <gpxtpx:course>88.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.779548" lon="-122.368879">
+        <time>2026-03-14T19:31:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.080</gpxtpx:speed>
+            <gpxtpx:course>207.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.779030" lon="-122.369324">
+        <time>2026-03-14T19:33:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.347</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.778706" lon="-122.369350">
+        <time>2026-03-14T19:36:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.154</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.778885" lon="-122.368798">
+        <time>2026-03-14T19:39:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.390</gpxtpx:speed>
+            <gpxtpx:course>91.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.779645" lon="-122.369581">
+        <time>2026-03-14T19:41:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.051</gpxtpx:speed>
+            <gpxtpx:course>313.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782537" lon="-122.370671">
+        <time>2026-03-14T19:44:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.514</gpxtpx:speed>
+            <gpxtpx:course>2.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784141" lon="-122.371566">
+        <time>2026-03-14T19:46:46Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.232</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783838" lon="-122.370677">
+        <time>2026-03-14T19:49:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.460</gpxtpx:speed>
+            <gpxtpx:course>121.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782742" lon="-122.369675">
+        <time>2026-03-14T19:51:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.835</gpxtpx:speed>
+            <gpxtpx:course>155.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782415" lon="-122.369393">
+        <time>2026-03-14T19:54:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.347</gpxtpx:speed>
+            <gpxtpx:course>148.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781312" lon="-122.368710">
+        <time>2026-03-14T19:57:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.660</gpxtpx:speed>
+            <gpxtpx:course>158.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.777804" lon="-122.366813">
+        <time>2026-03-14T19:59:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.466</gpxtpx:speed>
+            <gpxtpx:course>169.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.776352" lon="-122.366951">
+        <time>2026-03-14T20:02:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.144</gpxtpx:speed>
+            <gpxtpx:course>324.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.779440" lon="-122.369343">
+        <time>2026-03-14T20:04:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.390</gpxtpx:speed>
+            <gpxtpx:course>330.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782334" lon="-122.370931">
+        <time>2026-03-14T20:07:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.116</gpxtpx:speed>
+            <gpxtpx:course>340.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785398" lon="-122.372771">
+        <time>2026-03-14T20:10:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.377</gpxtpx:speed>
+            <gpxtpx:course>335.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788225" lon="-122.374375">
+        <time>2026-03-14T20:12:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.224</gpxtpx:speed>
+            <gpxtpx:course>338.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789263" lon="-122.373762">
+        <time>2026-03-14T20:15:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.520</gpxtpx:speed>
+            <gpxtpx:course>106.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789120" lon="-122.374200">
+        <time>2026-03-14T20:17:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.396</gpxtpx:speed>
+            <gpxtpx:course>205.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788255" lon="-122.374006">
+        <time>2026-03-14T20:20:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.028</gpxtpx:speed>
+            <gpxtpx:course>138.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.787074" lon="-122.370992">
+        <time>2026-03-14T20:22:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.060</gpxtpx:speed>
+            <gpxtpx:course>121.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.786011" lon="-122.369905">
+        <time>2026-03-14T20:25:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.351</gpxtpx:speed>
+            <gpxtpx:course>35.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.786629" lon="-122.371372">
+        <time>2026-03-14T20:28:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.940</gpxtpx:speed>
+            <gpxtpx:course>297.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785986" lon="-122.372591">
+        <time>2026-03-14T20:30:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.380</gpxtpx:speed>
+            <gpxtpx:course>162.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783795" lon="-122.371225">
+        <time>2026-03-14T20:33:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.440</gpxtpx:speed>
+            <gpxtpx:course>85.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784245" lon="-122.369767">
+        <time>2026-03-14T20:35:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.640</gpxtpx:speed>
+            <gpxtpx:course>149.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783074" lon="-122.368542">
+        <time>2026-03-14T20:38:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.240</gpxtpx:speed>
+            <gpxtpx:course>88.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782519" lon="-122.369594">
+        <time>2026-03-14T20:41:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.010</gpxtpx:speed>
+            <gpxtpx:course>191.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782455" lon="-122.370041">
+        <time>2026-03-14T20:43:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.347</gpxtpx:speed>
+            <gpxtpx:course>2.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781864" lon="-122.369492">
+        <time>2026-03-14T20:46:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.680</gpxtpx:speed>
+            <gpxtpx:course>184.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781984" lon="-122.369733">
+        <time>2026-03-14T20:48:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.692</gpxtpx:speed>
+            <gpxtpx:course>229.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.780575" lon="-122.368963">
+        <time>2026-03-14T20:51:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.800</gpxtpx:speed>
+            <gpxtpx:course>157.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.777189" lon="-122.366657">
+        <time>2026-03-14T20:53:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.749</gpxtpx:speed>
+            <gpxtpx:course>149.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.777273" lon="-122.367686">
+        <time>2026-03-14T20:56:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.524</gpxtpx:speed>
+            <gpxtpx:course>323.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.780206" lon="-122.369672">
+        <time>2026-03-14T20:59:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.267</gpxtpx:speed>
+            <gpxtpx:course>332.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782733" lon="-122.371555">
+        <time>2026-03-14T21:01:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.950</gpxtpx:speed>
+            <gpxtpx:course>320.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784814" lon="-122.372870">
+        <time>2026-03-14T21:04:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.360</gpxtpx:speed>
+            <gpxtpx:course>345.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.786803" lon="-122.373625">
+        <time>2026-03-14T21:06:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.718</gpxtpx:speed>
+            <gpxtpx:course>354.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785307" lon="-122.371628">
+        <time>2026-03-14T21:09:30Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.180</gpxtpx:speed>
+            <gpxtpx:course>134.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783139" lon="-122.369353">
+        <time>2026-03-14T21:12:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.560</gpxtpx:speed>
+            <gpxtpx:course>127.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782347" lon="-122.367894">
+        <time>2026-03-14T21:14:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.950</gpxtpx:speed>
+            <gpxtpx:course>159.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782374" lon="-122.369352">
+        <time>2026-03-14T21:17:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.750</gpxtpx:speed>
+            <gpxtpx:course>218.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781164" lon="-122.369421">
+        <time>2026-03-14T21:19:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.699</gpxtpx:speed>
+            <gpxtpx:course>155.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.777217" lon="-122.368043">
+        <time>2026-03-14T21:22:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.909</gpxtpx:speed>
+            <gpxtpx:course>148.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.777080" lon="-122.365980">
+        <time>2026-03-14T21:25:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.151</gpxtpx:speed>
+            <gpxtpx:course>350.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.779062" lon="-122.367269">
+        <time>2026-03-14T21:27:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.347</gpxtpx:speed>
+            <gpxtpx:course>328.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.780617" lon="-122.368433">
+        <time>2026-03-14T21:30:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.200</gpxtpx:speed>
+            <gpxtpx:course>322.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781982" lon="-122.369554">
+        <time>2026-03-14T21:32:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.070</gpxtpx:speed>
+            <gpxtpx:course>329.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783315" lon="-122.370511">
+        <time>2026-03-14T21:35:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.080</gpxtpx:speed>
+            <gpxtpx:course>324.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783775" lon="-122.371498">
+        <time>2026-03-14T21:37:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.689</gpxtpx:speed>
+            <gpxtpx:course>181.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.780329" lon="-122.369953">
+        <time>2026-03-14T21:40:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.658</gpxtpx:speed>
+            <gpxtpx:course>164.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.780284" lon="-122.367779">
+        <time>2026-03-14T21:43:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.288</gpxtpx:speed>
+            <gpxtpx:course>17.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785336" lon="-122.370376">
+        <time>2026-03-14T21:45:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.465</gpxtpx:speed>
+            <gpxtpx:course>329.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.790894" lon="-122.374280">
+        <time>2026-03-14T21:48:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.556</gpxtpx:speed>
+            <gpxtpx:course>326.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.796118" lon="-122.378668">
+        <time>2026-03-14T21:50:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.350</gpxtpx:speed>
+            <gpxtpx:course>325.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.801160" lon="-122.383354">
+        <time>2026-03-14T21:53:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.591</gpxtpx:speed>
+            <gpxtpx:course>325.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805693" lon="-122.387654">
+        <time>2026-03-14T21:56:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.479</gpxtpx:speed>
+            <gpxtpx:course>324.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809864" lon="-122.391389">
+        <time>2026-03-14T21:58:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.430</gpxtpx:speed>
+            <gpxtpx:course>325.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814124" lon="-122.394728">
+        <time>2026-03-14T22:01:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.060</gpxtpx:speed>
+            <gpxtpx:course>327.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819912" lon="-122.398842">
+        <time>2026-03-14T22:03:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.051</gpxtpx:speed>
+            <gpxtpx:course>331.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.826205" lon="-122.402841">
+        <time>2026-03-14T22:06:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.056</gpxtpx:speed>
+            <gpxtpx:course>334.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.831859" lon="-122.406342">
+        <time>2026-03-14T22:08:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.283</gpxtpx:speed>
+            <gpxtpx:course>334.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.835884" lon="-122.412265">
+        <time>2026-03-14T22:11:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.490</gpxtpx:speed>
+            <gpxtpx:course>294.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.837449" lon="-122.419333">
+        <time>2026-03-14T22:14:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.254</gpxtpx:speed>
+            <gpxtpx:course>278.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.838001" lon="-122.426934">
+        <time>2026-03-14T22:16:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.422</gpxtpx:speed>
+            <gpxtpx:course>272.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.838569" lon="-122.434901">
+        <time>2026-03-14T22:19:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.731</gpxtpx:speed>
+            <gpxtpx:course>275.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.838995" lon="-122.443134">
+        <time>2026-03-14T22:21:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.954</gpxtpx:speed>
+            <gpxtpx:course>263.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.839607" lon="-122.451512">
+        <time>2026-03-14T22:24:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.060</gpxtpx:speed>
+            <gpxtpx:course>277.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.839707" lon="-122.459745">
+        <time>2026-03-14T22:27:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.680</gpxtpx:speed>
+            <gpxtpx:course>272.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.839385" lon="-122.467373">
+        <time>2026-03-14T22:29:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.890</gpxtpx:speed>
+            <gpxtpx:course>193.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.834465" lon="-122.467981">
+        <time>2026-03-14T22:32:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.832</gpxtpx:speed>
+            <gpxtpx:course>184.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.828659" lon="-122.468769">
+        <time>2026-03-14T22:34:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.360</gpxtpx:speed>
+            <gpxtpx:course>190.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.822118" lon="-122.470509">
+        <time>2026-03-14T22:37:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.676</gpxtpx:speed>
+            <gpxtpx:course>212.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816114" lon="-122.472315">
+        <time>2026-03-14T22:40:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.200</gpxtpx:speed>
+            <gpxtpx:course>199.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815071" lon="-122.477515">
+        <time>2026-03-14T22:42:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.495</gpxtpx:speed>
+            <gpxtpx:course>285.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816851" lon="-122.477236">
+        <time>2026-03-14T22:45:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.186</gpxtpx:speed>
+            <gpxtpx:course>27.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817602" lon="-122.474974">
+        <time>2026-03-14T22:47:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.720</gpxtpx:speed>
+            <gpxtpx:course>77.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818446" lon="-122.471900">
+        <time>2026-03-14T22:50:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.240</gpxtpx:speed>
+            <gpxtpx:course>77.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818999" lon="-122.468430">
+        <time>2026-03-14T22:52:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.363</gpxtpx:speed>
+            <gpxtpx:course>78.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819743" lon="-122.464564">
+        <time>2026-03-14T22:55:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.794</gpxtpx:speed>
+            <gpxtpx:course>73.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819807" lon="-122.460260">
+        <time>2026-03-14T22:58:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.290</gpxtpx:speed>
+            <gpxtpx:course>100.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819683" lon="-122.454235">
+        <time>2026-03-14T23:00:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.917</gpxtpx:speed>
+            <gpxtpx:course>94.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819851" lon="-122.447908">
+        <time>2026-03-14T23:03:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.809</gpxtpx:speed>
+            <gpxtpx:course>82.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820332" lon="-122.441135">
+        <time>2026-03-14T23:06:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.192</gpxtpx:speed>
+            <gpxtpx:course>88.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820282" lon="-122.435596">
+        <time>2026-03-14T23:08:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.288</gpxtpx:speed>
+            <gpxtpx:course>98.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819685" lon="-122.429988">
+        <time>2026-03-14T23:11:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.089</gpxtpx:speed>
+            <gpxtpx:course>105.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819538" lon="-122.424672">
+        <time>2026-03-14T23:13:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.010</gpxtpx:speed>
+            <gpxtpx:course>92.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818333" lon="-122.419461">
+        <time>2026-03-14T23:16:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.260</gpxtpx:speed>
+            <gpxtpx:course>106.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817270" lon="-122.414152">
+        <time>2026-03-14T23:18:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.520</gpxtpx:speed>
+            <gpxtpx:course>108.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815905" lon="-122.408860">
+        <time>2026-03-14T23:21:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.209</gpxtpx:speed>
+            <gpxtpx:course>115.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.813659" lon="-122.404073">
+        <time>2026-03-14T23:24:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.110</gpxtpx:speed>
+            <gpxtpx:course>121.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.811651" lon="-122.400149">
+        <time>2026-03-14T23:26:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.966</gpxtpx:speed>
+            <gpxtpx:course>125.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809757" lon="-122.396397">
+        <time>2026-03-14T23:29:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.340</gpxtpx:speed>
+            <gpxtpx:course>104.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.808059" lon="-122.392926">
+        <time>2026-03-14T23:31:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.310</gpxtpx:speed>
+            <gpxtpx:course>105.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.807067" lon="-122.391213">
+        <time>2026-03-14T23:34:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.540</gpxtpx:speed>
+            <gpxtpx:course>155.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805017" lon="-122.389975">
+        <time>2026-03-14T23:37:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.399</gpxtpx:speed>
+            <gpxtpx:course>148.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.802127" lon="-122.388022">
+        <time>2026-03-14T23:39:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.830</gpxtpx:speed>
+            <gpxtpx:course>153.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.798310" lon="-122.385503">
+        <time>2026-03-14T23:42:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.804</gpxtpx:speed>
+            <gpxtpx:course>149.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.795517" lon="-122.383577">
+        <time>2026-03-14T23:44:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.426</gpxtpx:speed>
+            <gpxtpx:course>151.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.792679" lon="-122.381550">
+        <time>2026-03-14T23:47:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.087</gpxtpx:speed>
+            <gpxtpx:course>152.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.790300" lon="-122.379762">
+        <time>2026-03-14T23:49:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.886</gpxtpx:speed>
+            <gpxtpx:course>159.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788629" lon="-122.381426">
+        <time>2026-03-14T23:52:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.370</gpxtpx:speed>
+            <gpxtpx:course>223.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785843" lon="-122.383343">
+        <time>2026-03-14T23:55:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.116</gpxtpx:speed>
+            <gpxtpx:course>202.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783504" lon="-122.384126">
+        <time>2026-03-14T23:57:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.624</gpxtpx:speed>
+            <gpxtpx:course>199.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-03-15.gpx
+++ b/data/telemetry/tracks/2026-03-15.gpx
@@ -1,0 +1,712 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-03-15</name>
+    <time>2026-03-15T19:11:04Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-03-15</name>
+    <trkseg>
+      <trkpt lat="37.782960" lon="-122.382100">
+        <time>2026-03-15T19:11:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.363</gpxtpx:speed>
+            <gpxtpx:course>84.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783967" lon="-122.377827">
+        <time>2026-03-15T19:13:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.360</gpxtpx:speed>
+            <gpxtpx:course>67.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784346" lon="-122.374073">
+        <time>2026-03-15T19:16:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.310</gpxtpx:speed>
+            <gpxtpx:course>96.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783499" lon="-122.371113">
+        <time>2026-03-15T19:18:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.380</gpxtpx:speed>
+            <gpxtpx:course>144.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781404" lon="-122.370357">
+        <time>2026-03-15T19:21:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.310</gpxtpx:speed>
+            <gpxtpx:course>188.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.779841" lon="-122.370834">
+        <time>2026-03-15T19:24:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.180</gpxtpx:speed>
+            <gpxtpx:course>192.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.778932" lon="-122.369769">
+        <time>2026-03-15T19:26:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.284</gpxtpx:speed>
+            <gpxtpx:course>104.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.778521" lon="-122.368436">
+        <time>2026-03-15T19:29:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.870</gpxtpx:speed>
+            <gpxtpx:course>72.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.779286" lon="-122.368066">
+        <time>2026-03-15T19:31:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.700</gpxtpx:speed>
+            <gpxtpx:course>351.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781206" lon="-122.368856">
+        <time>2026-03-15T19:34:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.560</gpxtpx:speed>
+            <gpxtpx:course>288.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783391" lon="-122.369023">
+        <time>2026-03-15T19:36:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.220</gpxtpx:speed>
+            <gpxtpx:course>343.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784575" lon="-122.371006">
+        <time>2026-03-15T19:39:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.710</gpxtpx:speed>
+            <gpxtpx:course>265.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784261" lon="-122.371536">
+        <time>2026-03-15T19:42:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.280</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783960" lon="-122.371557">
+        <time>2026-03-15T19:44:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.210</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783667" lon="-122.371537">
+        <time>2026-03-15T19:47:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.352</gpxtpx:speed>
+            <gpxtpx:course>264.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783368" lon="-122.371554">
+        <time>2026-03-15T19:49:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.220</gpxtpx:speed>
+            <gpxtpx:course>264.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782698" lon="-122.371621">
+        <time>2026-03-15T19:52:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.078</gpxtpx:speed>
+            <gpxtpx:course>202.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781430" lon="-122.371325">
+        <time>2026-03-15T19:54:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.890</gpxtpx:speed>
+            <gpxtpx:course>140.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.780380" lon="-122.370518">
+        <time>2026-03-15T19:57:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.162</gpxtpx:speed>
+            <gpxtpx:course>213.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781700" lon="-122.370555">
+        <time>2026-03-15T20:00:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.162</gpxtpx:speed>
+            <gpxtpx:course>354.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783354" lon="-122.369484">
+        <time>2026-03-15T20:02:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.620</gpxtpx:speed>
+            <gpxtpx:course>56.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783529" lon="-122.369268">
+        <time>2026-03-15T20:05:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.091</gpxtpx:speed>
+            <gpxtpx:course>46.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784074" lon="-122.368146">
+        <time>2026-03-15T20:07:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.002</gpxtpx:speed>
+            <gpxtpx:course>61.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784693" lon="-122.366817">
+        <time>2026-03-15T20:10:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.470</gpxtpx:speed>
+            <gpxtpx:course>63.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785090" lon="-122.368797">
+        <time>2026-03-15T20:13:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.520</gpxtpx:speed>
+            <gpxtpx:course>306.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.786960" lon="-122.372500">
+        <time>2026-03-15T20:15:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.130</gpxtpx:speed>
+            <gpxtpx:course>286.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.786925" lon="-122.374281">
+        <time>2026-03-15T20:18:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.686</gpxtpx:speed>
+            <gpxtpx:course>141.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785881" lon="-122.372545">
+        <time>2026-03-15T20:20:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.311</gpxtpx:speed>
+            <gpxtpx:course>146.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783537" lon="-122.371333">
+        <time>2026-03-15T20:23:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.356</gpxtpx:speed>
+            <gpxtpx:course>169.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781276" lon="-122.369870">
+        <time>2026-03-15T20:25:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.510</gpxtpx:speed>
+            <gpxtpx:course>143.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782181" lon="-122.367555">
+        <time>2026-03-15T20:28:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.992</gpxtpx:speed>
+            <gpxtpx:course>354.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784865" lon="-122.367905">
+        <time>2026-03-15T20:31:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.360</gpxtpx:speed>
+            <gpxtpx:course>355.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789498" lon="-122.368248">
+        <time>2026-03-15T20:33:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.596</gpxtpx:speed>
+            <gpxtpx:course>347.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.794789" lon="-122.368915">
+        <time>2026-03-15T20:36:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.145</gpxtpx:speed>
+            <gpxtpx:course>351.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.800075" lon="-122.370238">
+        <time>2026-03-15T20:38:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.413</gpxtpx:speed>
+            <gpxtpx:course>350.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805360" lon="-122.370980">
+        <time>2026-03-15T20:41:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.054</gpxtpx:speed>
+            <gpxtpx:course>16.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806370" lon="-122.369176">
+        <time>2026-03-15T20:44:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.101</gpxtpx:speed>
+            <gpxtpx:course>186.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805683" lon="-122.367962">
+        <time>2026-03-15T20:46:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.140</gpxtpx:speed>
+            <gpxtpx:course>144.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804484" lon="-122.366879">
+        <time>2026-03-15T20:49:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.012</gpxtpx:speed>
+            <gpxtpx:course>106.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.803914" lon="-122.365285">
+        <time>2026-03-15T20:51:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.458</gpxtpx:speed>
+            <gpxtpx:course>73.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804588" lon="-122.362684">
+        <time>2026-03-15T20:54:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.695</gpxtpx:speed>
+            <gpxtpx:course>72.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804708" lon="-122.360074">
+        <time>2026-03-15T20:57:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.290</gpxtpx:speed>
+            <gpxtpx:course>105.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804895" lon="-122.357613">
+        <time>2026-03-15T20:59:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.307</gpxtpx:speed>
+            <gpxtpx:course>80.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804974" lon="-122.355265">
+        <time>2026-03-15T21:02:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.302</gpxtpx:speed>
+            <gpxtpx:course>95.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805059" lon="-122.352894">
+        <time>2026-03-15T21:04:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.320</gpxtpx:speed>
+            <gpxtpx:course>93.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804783" lon="-122.351054">
+        <time>2026-03-15T21:07:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.099</gpxtpx:speed>
+            <gpxtpx:course>148.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.803359" lon="-122.349700">
+        <time>2026-03-15T21:10:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.372</gpxtpx:speed>
+            <gpxtpx:course>136.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.801814" lon="-122.348125">
+        <time>2026-03-15T21:12:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.738</gpxtpx:speed>
+            <gpxtpx:course>152.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.799499" lon="-122.346535">
+        <time>2026-03-15T21:15:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.953</gpxtpx:speed>
+            <gpxtpx:course>154.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.796704" lon="-122.345842">
+        <time>2026-03-15T21:17:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.866</gpxtpx:speed>
+            <gpxtpx:course>165.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.794215" lon="-122.345089">
+        <time>2026-03-15T21:20:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.713</gpxtpx:speed>
+            <gpxtpx:course>160.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.792428" lon="-122.344202">
+        <time>2026-03-15T21:22:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.090</gpxtpx:speed>
+            <gpxtpx:course>149.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.791148" lon="-122.343610">
+        <time>2026-03-15T21:25:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.789</gpxtpx:speed>
+            <gpxtpx:course>156.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789932" lon="-122.343302">
+        <time>2026-03-15T21:28:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.832</gpxtpx:speed>
+            <gpxtpx:course>170.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788351" lon="-122.343011">
+        <time>2026-03-15T21:30:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.274</gpxtpx:speed>
+            <gpxtpx:course>171.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.786603" lon="-122.342842">
+        <time>2026-03-15T21:33:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.490</gpxtpx:speed>
+            <gpxtpx:course>181.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784995" lon="-122.342714">
+        <time>2026-03-15T21:35:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.053</gpxtpx:speed>
+            <gpxtpx:course>182.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783823" lon="-122.342784">
+        <time>2026-03-15T21:38:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.658</gpxtpx:speed>
+            <gpxtpx:course>189.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782849" lon="-122.342800">
+        <time>2026-03-15T21:41:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.599</gpxtpx:speed>
+            <gpxtpx:course>188.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782435" lon="-122.342717">
+        <time>2026-03-15T21:43:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+            <gpxtpx:course>155.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.780745" lon="-122.341413">
+        <time>2026-03-15T21:46:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.942</gpxtpx:speed>
+            <gpxtpx:course>170.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.776951" lon="-122.341155">
+        <time>2026-03-15T21:48:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.500</gpxtpx:speed>
+            <gpxtpx:course>232.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.774179" lon="-122.346695">
+        <time>2026-03-15T21:51:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.303</gpxtpx:speed>
+            <gpxtpx:course>225.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.770233" lon="-122.349839">
+        <time>2026-03-15T21:54:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.455</gpxtpx:speed>
+            <gpxtpx:course>226.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.766768" lon="-122.354062">
+        <time>2026-03-15T21:56:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.340</gpxtpx:speed>
+            <gpxtpx:course>206.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.762883" lon="-122.357322">
+        <time>2026-03-15T21:59:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.423</gpxtpx:speed>
+            <gpxtpx:course>217.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.760417" lon="-122.359742">
+        <time>2026-03-15T22:01:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.110</gpxtpx:speed>
+            <gpxtpx:course>238.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.760230" lon="-122.362598">
+        <time>2026-03-15T22:04:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.096</gpxtpx:speed>
+            <gpxtpx:course>273.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.759104" lon="-122.365758">
+        <time>2026-03-15T22:07:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.718</gpxtpx:speed>
+            <gpxtpx:course>240.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.759186" lon="-122.370356">
+        <time>2026-03-15T22:09:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.290</gpxtpx:speed>
+            <gpxtpx:course>300.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.762099" lon="-122.372692">
+        <time>2026-03-15T22:12:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.210</gpxtpx:speed>
+            <gpxtpx:course>5.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.767734" lon="-122.371623">
+        <time>2026-03-15T22:14:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.081</gpxtpx:speed>
+            <gpxtpx:course>0.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.773464" lon="-122.371491">
+        <time>2026-03-15T22:17:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.013</gpxtpx:speed>
+            <gpxtpx:course>359.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.776571" lon="-122.375134">
+        <time>2026-03-15T22:19:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.717</gpxtpx:speed>
+            <gpxtpx:course>289.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.777773" lon="-122.381396">
+        <time>2026-03-15T22:22:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.910</gpxtpx:speed>
+            <gpxtpx:course>273.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.777410" lon="-122.385485">
+        <time>2026-03-15T22:25:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.990</gpxtpx:speed>
+            <gpxtpx:course>259.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.777697" lon="-122.386550">
+        <time>2026-03-15T22:27:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.030</gpxtpx:speed>
+            <gpxtpx:course>274.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.778233" lon="-122.385479">
+        <time>2026-03-15T22:30:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.766</gpxtpx:speed>
+            <gpxtpx:course>41.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-03-21.gpx
+++ b/data/telemetry/tracks/2026-03-21.gpx
@@ -1,0 +1,3445 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-03-21</name>
+    <time>2026-03-21T00:21:16Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-03-21</name>
+    <trkseg>
+      <trkpt lat="37.783538" lon="-122.382622">
+        <time>2026-03-21T00:21:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.090</gpxtpx:speed>
+            <gpxtpx:course>54.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789687" lon="-122.380246">
+        <time>2026-03-21T00:23:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.189</gpxtpx:speed>
+            <gpxtpx:course>354.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.792730" lon="-122.382193">
+        <time>2026-03-21T00:26:30Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.052</gpxtpx:speed>
+            <gpxtpx:course>334.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.796152" lon="-122.382729">
+        <time>2026-03-21T00:29:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.283</gpxtpx:speed>
+            <gpxtpx:course>358.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.801235" lon="-122.384022">
+        <time>2026-03-21T00:31:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.910</gpxtpx:speed>
+            <gpxtpx:course>350.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.807929" lon="-122.385422">
+        <time>2026-03-21T00:34:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.049</gpxtpx:speed>
+            <gpxtpx:course>352.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814579" lon="-122.387947">
+        <time>2026-03-21T00:36:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.003</gpxtpx:speed>
+            <gpxtpx:course>340.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820417" lon="-122.392635">
+        <time>2026-03-21T00:39:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.380</gpxtpx:speed>
+            <gpxtpx:course>325.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.825700" lon="-122.398299">
+        <time>2026-03-21T00:42:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.750</gpxtpx:speed>
+            <gpxtpx:course>319.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.829740" lon="-122.404645">
+        <time>2026-03-21T00:44:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.472</gpxtpx:speed>
+            <gpxtpx:course>305.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.833025" lon="-122.411912">
+        <time>2026-03-21T00:47:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.680</gpxtpx:speed>
+            <gpxtpx:course>300.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.836358" lon="-122.419073">
+        <time>2026-03-21T00:49:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.150</gpxtpx:speed>
+            <gpxtpx:course>301.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.839227" lon="-122.426677">
+        <time>2026-03-21T00:52:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.730</gpxtpx:speed>
+            <gpxtpx:course>289.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.844032" lon="-122.433604">
+        <time>2026-03-21T00:55:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.320</gpxtpx:speed>
+            <gpxtpx:course>308.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.849096" lon="-122.440107">
+        <time>2026-03-21T00:57:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.184</gpxtpx:speed>
+            <gpxtpx:course>310.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.853586" lon="-122.445355">
+        <time>2026-03-21T01:00:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.382</gpxtpx:speed>
+            <gpxtpx:course>316.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.855824" lon="-122.447530">
+        <time>2026-03-21T01:02:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.360</gpxtpx:speed>
+            <gpxtpx:course>335.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.860065" lon="-122.449628">
+        <time>2026-03-21T01:05:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.404</gpxtpx:speed>
+            <gpxtpx:course>333.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.863539" lon="-122.449191">
+        <time>2026-03-21T01:08:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.700</gpxtpx:speed>
+            <gpxtpx:course>43.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.866002" lon="-122.445930">
+        <time>2026-03-21T01:10:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.560</gpxtpx:speed>
+            <gpxtpx:course>50.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.868607" lon="-122.442481">
+        <time>2026-03-21T01:13:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.940</gpxtpx:speed>
+            <gpxtpx:course>42.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871376" lon="-122.438923">
+        <time>2026-03-21T01:15:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.900</gpxtpx:speed>
+            <gpxtpx:course>48.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.874584" lon="-122.436692">
+        <time>2026-03-21T01:18:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.644</gpxtpx:speed>
+            <gpxtpx:course>16.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.878057" lon="-122.435116">
+        <time>2026-03-21T01:20:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.660</gpxtpx:speed>
+            <gpxtpx:course>7.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.881843" lon="-122.435137">
+        <time>2026-03-21T01:23:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.851</gpxtpx:speed>
+            <gpxtpx:course>358.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.885432" lon="-122.436609">
+        <time>2026-03-21T01:26:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.505</gpxtpx:speed>
+            <gpxtpx:course>343.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.888683" lon="-122.438059">
+        <time>2026-03-21T01:28:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.560</gpxtpx:speed>
+            <gpxtpx:course>343.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.891588" lon="-122.440793">
+        <time>2026-03-21T01:31:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.570</gpxtpx:speed>
+            <gpxtpx:course>346.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.894364" lon="-122.443927">
+        <time>2026-03-21T01:33:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.070</gpxtpx:speed>
+            <gpxtpx:course>293.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.895909" lon="-122.448727">
+        <time>2026-03-21T01:36:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.370</gpxtpx:speed>
+            <gpxtpx:course>268.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.896797" lon="-122.454455">
+        <time>2026-03-21T01:39:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.572</gpxtpx:speed>
+            <gpxtpx:course>293.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897518" lon="-122.456395">
+        <time>2026-03-21T01:41:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.670</gpxtpx:speed>
+            <gpxtpx:course>211.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897198" lon="-122.456270">
+        <time>2026-03-21T01:44:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.046</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897196" lon="-122.456210">
+        <time>2026-03-21T01:46:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.080</gpxtpx:speed>
+            <gpxtpx:course>119.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897184" lon="-122.456206">
+        <time>2026-03-21T01:49:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.029</gpxtpx:speed>
+            <gpxtpx:course>219.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897191" lon="-122.456238">
+        <time>2026-03-21T01:52:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>219.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897159" lon="-122.456254">
+        <time>2026-03-21T01:54:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.080</gpxtpx:speed>
+            <gpxtpx:course>219.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897159" lon="-122.456272">
+        <time>2026-03-21T01:57:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>236.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897153" lon="-122.456253">
+        <time>2026-03-21T01:59:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897158" lon="-122.456253">
+        <time>2026-03-21T02:02:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.037</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897148" lon="-122.456258">
+        <time>2026-03-21T02:05:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.017</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897167" lon="-122.456243">
+        <time>2026-03-21T02:07:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.051</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897184" lon="-122.456278">
+        <time>2026-03-21T02:10:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.120</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897205" lon="-122.456243">
+        <time>2026-03-21T02:13:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.079</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897179" lon="-122.456255">
+        <time>2026-03-21T02:15:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897185" lon="-122.456228">
+        <time>2026-03-21T02:18:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.076</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897245" lon="-122.456257">
+        <time>2026-03-21T02:20:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.070</gpxtpx:speed>
+            <gpxtpx:course>236.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897288" lon="-122.456276">
+        <time>2026-03-21T02:23:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.110</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897264" lon="-122.456255">
+        <time>2026-03-21T02:26:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>236.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897275" lon="-122.456266">
+        <time>2026-03-21T02:28:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.060</gpxtpx:speed>
+            <gpxtpx:course>236.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897188" lon="-122.456340">
+        <time>2026-03-21T02:31:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.107</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897184" lon="-122.456329">
+        <time>2026-03-21T02:33:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+            <gpxtpx:course>320.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897163" lon="-122.456328">
+        <time>2026-03-21T02:36:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.750</gpxtpx:speed>
+            <gpxtpx:course>341.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897176" lon="-122.456328">
+        <time>2026-03-21T02:39:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.057</gpxtpx:speed>
+            <gpxtpx:course>250.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897175" lon="-122.456328">
+        <time>2026-03-21T02:41:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.031</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897195" lon="-122.456280">
+        <time>2026-03-21T02:44:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.170</gpxtpx:speed>
+            <gpxtpx:course>250.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897209" lon="-122.456310">
+        <time>2026-03-21T02:46:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.060</gpxtpx:speed>
+            <gpxtpx:course>250.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897203" lon="-122.456332">
+        <time>2026-03-21T02:49:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.120</gpxtpx:speed>
+            <gpxtpx:course>250.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897197" lon="-122.456318">
+        <time>2026-03-21T02:52:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.016</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897194" lon="-122.456312">
+        <time>2026-03-21T02:54:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.090</gpxtpx:speed>
+            <gpxtpx:course>250.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897197" lon="-122.456307">
+        <time>2026-03-21T02:57:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.290</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897180" lon="-122.456343">
+        <time>2026-03-21T02:59:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.043</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897193" lon="-122.456322">
+        <time>2026-03-21T03:02:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.060</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897183" lon="-122.456321">
+        <time>2026-03-21T03:05:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.039</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897204" lon="-122.456335">
+        <time>2026-03-21T03:07:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.070</gpxtpx:speed>
+            <gpxtpx:course>308.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897188" lon="-122.456334">
+        <time>2026-03-21T03:10:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.028</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897179" lon="-122.456335">
+        <time>2026-03-21T03:12:46Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.032</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897196" lon="-122.456328">
+        <time>2026-03-21T03:15:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+            <gpxtpx:course>308.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897182" lon="-122.456330">
+        <time>2026-03-21T03:17:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.067</gpxtpx:speed>
+            <gpxtpx:course>308.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897184" lon="-122.456332">
+        <time>2026-03-21T03:20:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>308.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897188" lon="-122.456348">
+        <time>2026-03-21T03:23:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.060</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897202" lon="-122.456346">
+        <time>2026-03-21T03:25:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.021</gpxtpx:speed>
+            <gpxtpx:course>308.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897186" lon="-122.456369">
+        <time>2026-03-21T03:28:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.036</gpxtpx:speed>
+            <gpxtpx:course>308.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897214" lon="-122.456360">
+        <time>2026-03-21T03:30:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.072</gpxtpx:speed>
+            <gpxtpx:course>22.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897253" lon="-122.456448">
+        <time>2026-03-21T03:33:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+            <gpxtpx:course>22.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897288" lon="-122.456464">
+        <time>2026-03-21T03:36:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>22.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897258" lon="-122.456466">
+        <time>2026-03-21T03:38:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.068</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897280" lon="-122.456444">
+        <time>2026-03-21T03:41:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.071</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897285" lon="-122.456444">
+        <time>2026-03-21T03:43:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.011</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897279" lon="-122.456450">
+        <time>2026-03-21T03:46:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.015</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897296" lon="-122.456446">
+        <time>2026-03-21T03:49:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.026</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897292" lon="-122.456451">
+        <time>2026-03-21T03:51:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.047</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897309" lon="-122.456458">
+        <time>2026-03-21T03:54:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.003</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897259" lon="-122.456430">
+        <time>2026-03-21T03:56:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.034</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897283" lon="-122.456440">
+        <time>2026-03-21T03:59:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.018</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897269" lon="-122.456473">
+        <time>2026-03-21T04:02:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.029</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897266" lon="-122.456454">
+        <time>2026-03-21T04:04:46Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.022</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897248" lon="-122.456462">
+        <time>2026-03-21T04:07:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.014</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897254" lon="-122.456450">
+        <time>2026-03-21T04:09:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.015</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897269" lon="-122.456458">
+        <time>2026-03-21T04:12:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897260" lon="-122.456453">
+        <time>2026-03-21T04:15:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.019</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897255" lon="-122.456470">
+        <time>2026-03-21T04:17:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.098</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897217" lon="-122.456459">
+        <time>2026-03-21T04:20:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.008</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897223" lon="-122.456453">
+        <time>2026-03-21T04:22:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.026</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897232" lon="-122.456455">
+        <time>2026-03-21T04:25:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.016</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897228" lon="-122.456456">
+        <time>2026-03-21T04:28:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.024</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897244" lon="-122.456452">
+        <time>2026-03-21T04:30:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.053</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897232" lon="-122.456419">
+        <time>2026-03-21T04:33:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>103.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897268" lon="-122.456430">
+        <time>2026-03-21T04:35:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>130.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897240" lon="-122.456445">
+        <time>2026-03-21T04:38:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>130.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897249" lon="-122.456439">
+        <time>2026-03-21T04:41:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.034</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897250" lon="-122.456446">
+        <time>2026-03-21T04:43:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.080</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897234" lon="-122.456470">
+        <time>2026-03-21T04:46:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897256" lon="-122.456441">
+        <time>2026-03-21T04:48:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.014</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897252" lon="-122.456431">
+        <time>2026-03-21T04:51:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.034</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897248" lon="-122.456437">
+        <time>2026-03-21T04:54:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.053</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897263" lon="-122.456437">
+        <time>2026-03-21T04:56:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.018</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897265" lon="-122.456425">
+        <time>2026-03-21T04:59:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.025</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897282" lon="-122.456448">
+        <time>2026-03-21T05:01:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897286" lon="-122.456427">
+        <time>2026-03-21T05:04:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.058</gpxtpx:speed>
+            <gpxtpx:course>135.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897294" lon="-122.456418">
+        <time>2026-03-21T05:07:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.010</gpxtpx:speed>
+            <gpxtpx:course>135.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897273" lon="-122.456430">
+        <time>2026-03-21T05:09:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.032</gpxtpx:speed>
+            <gpxtpx:course>185.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897267" lon="-122.456444">
+        <time>2026-03-21T05:12:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.060</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897314" lon="-122.456454">
+        <time>2026-03-21T05:14:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.012</gpxtpx:speed>
+            <gpxtpx:course>31.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897278" lon="-122.456462">
+        <time>2026-03-21T05:17:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897280" lon="-122.456455">
+        <time>2026-03-21T05:20:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.023</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897256" lon="-122.456461">
+        <time>2026-03-21T05:22:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.013</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897291" lon="-122.456451">
+        <time>2026-03-21T05:25:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>20.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897270" lon="-122.456467">
+        <time>2026-03-21T05:28:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.002</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897289" lon="-122.456461">
+        <time>2026-03-21T05:30:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.024</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897296" lon="-122.456441">
+        <time>2026-03-21T05:33:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>20.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897281" lon="-122.456465">
+        <time>2026-03-21T05:35:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.039</gpxtpx:speed>
+            <gpxtpx:course>20.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897251" lon="-122.456460">
+        <time>2026-03-21T05:38:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.059</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897279" lon="-122.456445">
+        <time>2026-03-21T05:41:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897256" lon="-122.456438">
+        <time>2026-03-21T05:43:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.007</gpxtpx:speed>
+            <gpxtpx:course>20.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897255" lon="-122.456433">
+        <time>2026-03-21T05:46:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.018</gpxtpx:speed>
+            <gpxtpx:course>20.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897266" lon="-122.456434">
+        <time>2026-03-21T05:48:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.036</gpxtpx:speed>
+            <gpxtpx:course>20.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897254" lon="-122.456436">
+        <time>2026-03-21T05:51:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.077</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897262" lon="-122.456433">
+        <time>2026-03-21T05:54:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.068</gpxtpx:speed>
+            <gpxtpx:course>20.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897299" lon="-122.456462">
+        <time>2026-03-21T05:56:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.140</gpxtpx:speed>
+            <gpxtpx:course>20.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897343" lon="-122.456466">
+        <time>2026-03-21T05:59:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.056</gpxtpx:speed>
+            <gpxtpx:course>20.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897378" lon="-122.456426">
+        <time>2026-03-21T06:01:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>20.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897447" lon="-122.456514">
+        <time>2026-03-21T06:04:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.031</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897434" lon="-122.456508">
+        <time>2026-03-21T06:07:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.059</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897442" lon="-122.456496">
+        <time>2026-03-21T06:10:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.079</gpxtpx:speed>
+            <gpxtpx:course>31.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897437" lon="-122.456517">
+        <time>2026-03-21T06:12:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.021</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897420" lon="-122.456502">
+        <time>2026-03-21T06:15:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.027</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897435" lon="-122.456510">
+        <time>2026-03-21T06:17:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.007</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897432" lon="-122.456519">
+        <time>2026-03-21T06:20:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.053</gpxtpx:speed>
+            <gpxtpx:course>11.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897445" lon="-122.456528">
+        <time>2026-03-21T06:23:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.090</gpxtpx:speed>
+            <gpxtpx:course>11.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897440" lon="-122.456546">
+        <time>2026-03-21T06:25:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.160</gpxtpx:speed>
+            <gpxtpx:course>11.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897441" lon="-122.456501">
+        <time>2026-03-21T06:28:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>11.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897449" lon="-122.456493">
+        <time>2026-03-21T06:30:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.280</gpxtpx:speed>
+            <gpxtpx:course>11.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897463" lon="-122.456510">
+        <time>2026-03-21T06:33:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.010</gpxtpx:speed>
+            <gpxtpx:course>12.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897458" lon="-122.456515">
+        <time>2026-03-21T06:36:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.080</gpxtpx:speed>
+            <gpxtpx:course>12.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897440" lon="-122.456507">
+        <time>2026-03-21T06:38:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.016</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897473" lon="-122.456529">
+        <time>2026-03-21T06:41:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>12.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897476" lon="-122.456528">
+        <time>2026-03-21T06:43:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>12.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897453" lon="-122.456520">
+        <time>2026-03-21T06:46:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.014</gpxtpx:speed>
+            <gpxtpx:course>12.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897448" lon="-122.456508">
+        <time>2026-03-21T06:48:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.049</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897435" lon="-122.456509">
+        <time>2026-03-21T06:51:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.004</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897430" lon="-122.456506">
+        <time>2026-03-21T06:54:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.015</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897438" lon="-122.456498">
+        <time>2026-03-21T06:56:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.187</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897416" lon="-122.456488">
+        <time>2026-03-21T06:59:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.011</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897432" lon="-122.456472">
+        <time>2026-03-21T07:01:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>337.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897426" lon="-122.456498">
+        <time>2026-03-21T07:04:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.041</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897450" lon="-122.456487">
+        <time>2026-03-21T07:07:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.099</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897427" lon="-122.456357">
+        <time>2026-03-21T07:09:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.260</gpxtpx:speed>
+            <gpxtpx:course>337.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897433" lon="-122.456356">
+        <time>2026-03-21T07:12:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.017</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897486" lon="-122.456525">
+        <time>2026-03-21T07:14:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.070</gpxtpx:speed>
+            <gpxtpx:course>337.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897374" lon="-122.456543">
+        <time>2026-03-21T07:17:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.070</gpxtpx:speed>
+            <gpxtpx:course>337.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897382" lon="-122.456432">
+        <time>2026-03-21T07:20:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.011</gpxtpx:speed>
+            <gpxtpx:course>337.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897370" lon="-122.456447">
+        <time>2026-03-21T07:23:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.000</gpxtpx:speed>
+            <gpxtpx:course>337.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897359" lon="-122.456463">
+        <time>2026-03-21T07:25:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.068</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897410" lon="-122.456472">
+        <time>2026-03-21T07:28:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>337.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897402" lon="-122.456405">
+        <time>2026-03-21T07:30:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.067</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897381" lon="-122.456293">
+        <time>2026-03-21T07:33:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.240</gpxtpx:speed>
+            <gpxtpx:course>337.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897332" lon="-122.456295">
+        <time>2026-03-21T07:35:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.033</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897376" lon="-122.456283">
+        <time>2026-03-21T07:38:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.042</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897368" lon="-122.456272">
+        <time>2026-03-21T07:41:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>222.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897362" lon="-122.456262">
+        <time>2026-03-21T07:43:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.107</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897367" lon="-122.456177">
+        <time>2026-03-21T07:46:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.080</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897406" lon="-122.456166">
+        <time>2026-03-21T07:48:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.107</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897425" lon="-122.456211">
+        <time>2026-03-21T07:51:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.080</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897421" lon="-122.456289">
+        <time>2026-03-21T07:54:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.054</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897408" lon="-122.456375">
+        <time>2026-03-21T07:56:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.042</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897363" lon="-122.456382">
+        <time>2026-03-21T07:59:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.037</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897348" lon="-122.456418">
+        <time>2026-03-21T08:02:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897322" lon="-122.456439">
+        <time>2026-03-21T08:04:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897265" lon="-122.456427">
+        <time>2026-03-21T08:07:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.018</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897311" lon="-122.456435">
+        <time>2026-03-21T08:09:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.320</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897408" lon="-122.456382">
+        <time>2026-03-21T08:12:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897455" lon="-122.456297">
+        <time>2026-03-21T08:15:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.045</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897483" lon="-122.456310">
+        <time>2026-03-21T08:17:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897461" lon="-122.456301">
+        <time>2026-03-21T08:20:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897444" lon="-122.456277">
+        <time>2026-03-21T08:22:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.045</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897492" lon="-122.456292">
+        <time>2026-03-21T08:25:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.042</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897465" lon="-122.456340">
+        <time>2026-03-21T08:28:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.009</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897442" lon="-122.456346">
+        <time>2026-03-21T08:30:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.070</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897463" lon="-122.456344">
+        <time>2026-03-21T08:33:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.060</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897492" lon="-122.456257">
+        <time>2026-03-21T08:35:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.032</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897478" lon="-122.456282">
+        <time>2026-03-21T08:38:30Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897462" lon="-122.456318">
+        <time>2026-03-21T08:41:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.021</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897472" lon="-122.456281">
+        <time>2026-03-21T08:43:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.070</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897448" lon="-122.456285">
+        <time>2026-03-21T08:46:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.199</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897449" lon="-122.456316">
+        <time>2026-03-21T08:49:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.056</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897461" lon="-122.456384">
+        <time>2026-03-21T08:51:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.049</gpxtpx:speed>
+            <gpxtpx:course>236.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897470" lon="-122.456354">
+        <time>2026-03-21T08:54:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.073</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897478" lon="-122.456336">
+        <time>2026-03-21T08:56:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.007</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897465" lon="-122.456291">
+        <time>2026-03-21T08:59:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.048</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897377" lon="-122.456292">
+        <time>2026-03-21T09:02:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.119</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897331" lon="-122.456243">
+        <time>2026-03-21T09:04:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.070</gpxtpx:speed>
+            <gpxtpx:course>163.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897357" lon="-122.456259">
+        <time>2026-03-21T09:07:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.093</gpxtpx:speed>
+            <gpxtpx:course>277.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897442" lon="-122.456228">
+        <time>2026-03-21T09:10:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.077</gpxtpx:speed>
+            <gpxtpx:course>277.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897472" lon="-122.456354">
+        <time>2026-03-21T09:12:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.051</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897476" lon="-122.456430">
+        <time>2026-03-21T09:15:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.066</gpxtpx:speed>
+            <gpxtpx:course>96.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897474" lon="-122.456409">
+        <time>2026-03-21T09:17:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.190</gpxtpx:speed>
+            <gpxtpx:course>114.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897479" lon="-122.456357">
+        <time>2026-03-21T09:20:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.080</gpxtpx:speed>
+            <gpxtpx:course>72.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897422" lon="-122.456385">
+        <time>2026-03-21T09:23:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.110</gpxtpx:speed>
+            <gpxtpx:course>98.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897477" lon="-122.456340">
+        <time>2026-03-21T09:25:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.048</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897393" lon="-122.456328">
+        <time>2026-03-21T09:28:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.102</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897369" lon="-122.456295">
+        <time>2026-03-21T09:30:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>98.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897394" lon="-122.456349">
+        <time>2026-03-21T09:33:30Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.026</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897396" lon="-122.456300">
+        <time>2026-03-21T09:36:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.066</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897358" lon="-122.456243">
+        <time>2026-03-21T09:38:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.260</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897392" lon="-122.456281">
+        <time>2026-03-21T09:41:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.071</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897373" lon="-122.456242">
+        <time>2026-03-21T09:43:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.051</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897380" lon="-122.456271">
+        <time>2026-03-21T09:46:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.009</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897376" lon="-122.456253">
+        <time>2026-03-21T09:48:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.027</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897364" lon="-122.456276">
+        <time>2026-03-21T09:51:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.031</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897373" lon="-122.456256">
+        <time>2026-03-21T09:54:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.029</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897331" lon="-122.456236">
+        <time>2026-03-21T09:56:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897328" lon="-122.456256">
+        <time>2026-03-21T09:59:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.090</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897303" lon="-122.456270">
+        <time>2026-03-21T10:01:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+            <gpxtpx:course>156.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897307" lon="-122.456249">
+        <time>2026-03-21T10:04:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.090</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897315" lon="-122.456258">
+        <time>2026-03-21T10:07:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+            <gpxtpx:course>159.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897320" lon="-122.456278">
+        <time>2026-03-21T10:09:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.015</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897334" lon="-122.456264">
+        <time>2026-03-21T10:12:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.015</gpxtpx:speed>
+            <gpxtpx:course>159.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897301" lon="-122.456264">
+        <time>2026-03-21T10:14:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>136.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897317" lon="-122.456268">
+        <time>2026-03-21T10:17:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.011</gpxtpx:speed>
+            <gpxtpx:course>341.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897317" lon="-122.456239">
+        <time>2026-03-21T10:20:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.016</gpxtpx:speed>
+            <gpxtpx:course>341.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897308" lon="-122.456240">
+        <time>2026-03-21T10:22:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.160</gpxtpx:speed>
+            <gpxtpx:course>341.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897346" lon="-122.456249">
+        <time>2026-03-21T10:25:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.033</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897329" lon="-122.456213">
+        <time>2026-03-21T10:27:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.014</gpxtpx:speed>
+            <gpxtpx:course>341.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897347" lon="-122.456243">
+        <time>2026-03-21T10:30:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>341.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897343" lon="-122.456226">
+        <time>2026-03-21T10:32:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>340.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897316" lon="-122.456223">
+        <time>2026-03-21T10:35:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.004</gpxtpx:speed>
+            <gpxtpx:course>340.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897328" lon="-122.456224">
+        <time>2026-03-21T10:38:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>340.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897307" lon="-122.456227">
+        <time>2026-03-21T10:40:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.000</gpxtpx:speed>
+            <gpxtpx:course>340.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897301" lon="-122.456227">
+        <time>2026-03-21T10:43:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>340.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897317" lon="-122.456209">
+        <time>2026-03-21T10:45:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.102</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897308" lon="-122.456146">
+        <time>2026-03-21T10:48:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.066</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897328" lon="-122.456136">
+        <time>2026-03-21T10:51:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.099</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897302" lon="-122.456126">
+        <time>2026-03-21T10:54:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>227.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897329" lon="-122.456134">
+        <time>2026-03-21T10:56:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.080</gpxtpx:speed>
+            <gpxtpx:course>217.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897297" lon="-122.456125">
+        <time>2026-03-21T10:59:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.070</gpxtpx:speed>
+            <gpxtpx:course>294.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897309" lon="-122.456135">
+        <time>2026-03-21T11:02:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.024</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897309" lon="-122.456137">
+        <time>2026-03-21T11:04:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.072</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897295" lon="-122.456130">
+        <time>2026-03-21T11:07:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>278.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897313" lon="-122.456141">
+        <time>2026-03-21T11:10:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.085</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897301" lon="-122.456154">
+        <time>2026-03-21T11:12:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.060</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897303" lon="-122.456150">
+        <time>2026-03-21T11:15:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.036</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897307" lon="-122.456147">
+        <time>2026-03-21T11:17:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.006</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897322" lon="-122.456142">
+        <time>2026-03-21T11:20:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>303.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897297" lon="-122.456149">
+        <time>2026-03-21T11:23:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.140</gpxtpx:speed>
+            <gpxtpx:course>303.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897298" lon="-122.456153">
+        <time>2026-03-21T11:26:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.006</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897294" lon="-122.456155">
+        <time>2026-03-21T11:28:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897277" lon="-122.456147">
+        <time>2026-03-21T11:31:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.010</gpxtpx:speed>
+            <gpxtpx:course>4.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897297" lon="-122.456150">
+        <time>2026-03-21T11:33:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>4.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897326" lon="-122.456153">
+        <time>2026-03-21T11:36:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.110</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897290" lon="-122.456142">
+        <time>2026-03-21T11:39:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.059</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897289" lon="-122.456158">
+        <time>2026-03-21T11:41:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.017</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897271" lon="-122.456143">
+        <time>2026-03-21T11:44:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.042</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897275" lon="-122.456156">
+        <time>2026-03-21T11:46:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897265" lon="-122.456148">
+        <time>2026-03-21T11:49:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897267" lon="-122.456158">
+        <time>2026-03-21T11:52:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.033</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897275" lon="-122.456155">
+        <time>2026-03-21T11:54:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.041</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897264" lon="-122.456151">
+        <time>2026-03-21T11:57:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897267" lon="-122.456152">
+        <time>2026-03-21T11:59:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.010</gpxtpx:speed>
+            <gpxtpx:course>4.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897270" lon="-122.456148">
+        <time>2026-03-21T12:02:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.032</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897279" lon="-122.456140">
+        <time>2026-03-21T12:05:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.012</gpxtpx:speed>
+            <gpxtpx:course>4.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897275" lon="-122.456136">
+        <time>2026-03-21T12:08:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.017</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897272" lon="-122.456144">
+        <time>2026-03-21T12:10:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.016</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897276" lon="-122.456142">
+        <time>2026-03-21T12:13:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.021</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897284" lon="-122.456144">
+        <time>2026-03-21T12:16:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.047</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897270" lon="-122.456155">
+        <time>2026-03-21T12:18:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.041</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897270" lon="-122.456139">
+        <time>2026-03-21T12:21:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.059</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897284" lon="-122.456138">
+        <time>2026-03-21T12:23:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897277" lon="-122.456145">
+        <time>2026-03-21T12:26:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897281" lon="-122.456152">
+        <time>2026-03-21T12:28:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897283" lon="-122.456155">
+        <time>2026-03-21T12:31:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897298" lon="-122.456147">
+        <time>2026-03-21T12:34:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897289" lon="-122.456157">
+        <time>2026-03-21T12:36:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.029</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897287" lon="-122.456165">
+        <time>2026-03-21T12:39:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897288" lon="-122.456145">
+        <time>2026-03-21T12:42:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.010</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897285" lon="-122.456143">
+        <time>2026-03-21T12:44:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.080</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897272" lon="-122.456148">
+        <time>2026-03-21T12:47:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897267" lon="-122.456146">
+        <time>2026-03-21T12:49:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897283" lon="-122.456146">
+        <time>2026-03-21T12:52:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.044</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897272" lon="-122.456141">
+        <time>2026-03-21T12:54:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897270" lon="-122.456145">
+        <time>2026-03-21T12:57:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.000</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897281" lon="-122.456142">
+        <time>2026-03-21T13:00:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897272" lon="-122.456148">
+        <time>2026-03-21T13:02:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.025</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897252" lon="-122.456141">
+        <time>2026-03-21T13:05:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.019</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897247" lon="-122.456142">
+        <time>2026-03-21T13:08:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897249" lon="-122.456131">
+        <time>2026-03-21T13:10:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.037</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897266" lon="-122.456139">
+        <time>2026-03-21T13:13:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.036</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897260" lon="-122.456160">
+        <time>2026-03-21T13:16:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.120</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897262" lon="-122.456135">
+        <time>2026-03-21T13:18:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897273" lon="-122.456131">
+        <time>2026-03-21T13:21:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897292" lon="-122.456156">
+        <time>2026-03-21T13:24:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.150</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897284" lon="-122.456151">
+        <time>2026-03-21T13:26:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897284" lon="-122.456157">
+        <time>2026-03-21T13:29:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.023</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897281" lon="-122.456161">
+        <time>2026-03-21T13:31:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.016</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897257" lon="-122.456150">
+        <time>2026-03-21T13:34:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.060</gpxtpx:speed>
+            <gpxtpx:course>334.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897255" lon="-122.456147">
+        <time>2026-03-21T13:37:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897259" lon="-122.456127">
+        <time>2026-03-21T13:39:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.070</gpxtpx:speed>
+            <gpxtpx:course>279.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897253" lon="-122.456144">
+        <time>2026-03-21T13:42:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.060</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897276" lon="-122.456151">
+        <time>2026-03-21T13:44:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.046</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897273" lon="-122.456160">
+        <time>2026-03-21T13:47:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+            <gpxtpx:course>279.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897272" lon="-122.456155">
+        <time>2026-03-21T13:50:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.006</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897282" lon="-122.456149">
+        <time>2026-03-21T13:52:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.019</gpxtpx:speed>
+            <gpxtpx:course>242.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897277" lon="-122.456162">
+        <time>2026-03-21T13:55:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.029</gpxtpx:speed>
+            <gpxtpx:course>242.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897289" lon="-122.456159">
+        <time>2026-03-21T13:57:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.023</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897278" lon="-122.456150">
+        <time>2026-03-21T14:00:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>242.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897299" lon="-122.456156">
+        <time>2026-03-21T14:03:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>242.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897271" lon="-122.456157">
+        <time>2026-03-21T14:05:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.010</gpxtpx:speed>
+            <gpxtpx:course>242.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897294" lon="-122.456149">
+        <time>2026-03-21T14:08:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+            <gpxtpx:course>242.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897282" lon="-122.456146">
+        <time>2026-03-21T14:10:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>199.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897272" lon="-122.456159">
+        <time>2026-03-21T14:13:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>199.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897274" lon="-122.456141">
+        <time>2026-03-21T14:15:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.059</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897277" lon="-122.456145">
+        <time>2026-03-21T14:18:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>113.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897287" lon="-122.456141">
+        <time>2026-03-21T14:21:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.090</gpxtpx:speed>
+            <gpxtpx:course>113.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897271" lon="-122.456156">
+        <time>2026-03-21T14:23:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>113.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897261" lon="-122.456160">
+        <time>2026-03-21T14:26:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.220</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897278" lon="-122.456148">
+        <time>2026-03-21T14:28:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897290" lon="-122.456118">
+        <time>2026-03-21T14:31:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.260</gpxtpx:speed>
+            <gpxtpx:course>62.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897276" lon="-122.456147">
+        <time>2026-03-21T14:34:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.033</gpxtpx:speed>
+            <gpxtpx:course>218.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897276" lon="-122.456149">
+        <time>2026-03-21T14:36:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.036</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897272" lon="-122.456170">
+        <time>2026-03-21T14:39:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.070</gpxtpx:speed>
+            <gpxtpx:course>238.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897292" lon="-122.456159">
+        <time>2026-03-21T14:42:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.063</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897331" lon="-122.456170">
+        <time>2026-03-21T14:44:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.032</gpxtpx:speed>
+            <gpxtpx:course>102.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897285" lon="-122.456150">
+        <time>2026-03-21T14:47:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.023</gpxtpx:speed>
+            <gpxtpx:course>147.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897284" lon="-122.456148">
+        <time>2026-03-21T14:49:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.010</gpxtpx:speed>
+            <gpxtpx:course>191.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897281" lon="-122.456152">
+        <time>2026-03-21T14:52:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.026</gpxtpx:speed>
+            <gpxtpx:course>191.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897288" lon="-122.456157">
+        <time>2026-03-21T14:55:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.070</gpxtpx:speed>
+            <gpxtpx:course>191.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897301" lon="-122.456141">
+        <time>2026-03-21T14:57:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.074</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897306" lon="-122.456138">
+        <time>2026-03-21T15:00:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.065</gpxtpx:speed>
+            <gpxtpx:course>191.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897309" lon="-122.456146">
+        <time>2026-03-21T15:02:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.032</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897292" lon="-122.456145">
+        <time>2026-03-21T15:05:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897281" lon="-122.456145">
+        <time>2026-03-21T15:07:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.026</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897292" lon="-122.456146">
+        <time>2026-03-21T15:10:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+            <gpxtpx:course>193.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897298" lon="-122.456153">
+        <time>2026-03-21T15:13:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>193.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897286" lon="-122.456145">
+        <time>2026-03-21T15:15:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897286" lon="-122.456134">
+        <time>2026-03-21T15:18:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.097</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897263" lon="-122.456132">
+        <time>2026-03-21T15:20:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.079</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897264" lon="-122.456124">
+        <time>2026-03-21T15:23:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.005</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897268" lon="-122.456150">
+        <time>2026-03-21T15:26:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.009</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897270" lon="-122.456152">
+        <time>2026-03-21T15:28:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.060</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897280" lon="-122.456152">
+        <time>2026-03-21T15:31:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897290" lon="-122.456140">
+        <time>2026-03-21T15:33:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.033</gpxtpx:speed>
+            <gpxtpx:course>193.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897298" lon="-122.456141">
+        <time>2026-03-21T15:36:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>263.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897259" lon="-122.456148">
+        <time>2026-03-21T15:39:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.044</gpxtpx:speed>
+            <gpxtpx:course>244.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897261" lon="-122.456140">
+        <time>2026-03-21T15:41:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.019</gpxtpx:speed>
+            <gpxtpx:course>244.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897270" lon="-122.456148">
+        <time>2026-03-21T15:44:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>226.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897250" lon="-122.456160">
+        <time>2026-03-21T15:47:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.026</gpxtpx:speed>
+            <gpxtpx:course>226.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897249" lon="-122.456154">
+        <time>2026-03-21T15:49:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.016</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897255" lon="-122.456167">
+        <time>2026-03-21T15:52:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>282.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897233" lon="-122.456166">
+        <time>2026-03-21T15:54:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>282.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897244" lon="-122.456164">
+        <time>2026-03-21T15:57:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.048</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897267" lon="-122.456156">
+        <time>2026-03-21T16:00:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+            <gpxtpx:course>282.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897238" lon="-122.456168">
+        <time>2026-03-21T16:02:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.029</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897253" lon="-122.456174">
+        <time>2026-03-21T16:05:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.110</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897256" lon="-122.456177">
+        <time>2026-03-21T16:07:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.051</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897281" lon="-122.456160">
+        <time>2026-03-21T16:10:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.043</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897278" lon="-122.456191">
+        <time>2026-03-21T16:13:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897289" lon="-122.456160">
+        <time>2026-03-21T16:15:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.029</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897300" lon="-122.456171">
+        <time>2026-03-21T16:18:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.033</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897291" lon="-122.456159">
+        <time>2026-03-21T16:20:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>282.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897292" lon="-122.456182">
+        <time>2026-03-21T16:23:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.061</gpxtpx:speed>
+            <gpxtpx:course>282.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897289" lon="-122.456239">
+        <time>2026-03-21T16:26:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.061</gpxtpx:speed>
+            <gpxtpx:course>352.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897286" lon="-122.456396">
+        <time>2026-03-21T16:28:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.230</gpxtpx:speed>
+            <gpxtpx:course>332.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897337" lon="-122.456485">
+        <time>2026-03-21T16:41:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.035</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897215" lon="-122.456384">
+        <time>2026-03-21T16:51:30Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.034</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897206" lon="-122.456390">
+        <time>2026-03-21T16:54:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.013</gpxtpx:speed>
+            <gpxtpx:course>332.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897224" lon="-122.456407">
+        <time>2026-03-21T16:56:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.040</gpxtpx:speed>
+            <gpxtpx:course>332.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897202" lon="-122.456414">
+        <time>2026-03-21T16:59:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.018</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897189" lon="-122.456383">
+        <time>2026-03-21T17:02:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.022</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897196" lon="-122.456406">
+        <time>2026-03-21T17:04:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897219" lon="-122.456422">
+        <time>2026-03-21T17:07:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>332.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897208" lon="-122.456433">
+        <time>2026-03-21T17:09:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.016</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897230" lon="-122.456435">
+        <time>2026-03-21T17:12:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.170</gpxtpx:speed>
+            <gpxtpx:course>332.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897227" lon="-122.456461">
+        <time>2026-03-21T17:14:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+            <gpxtpx:course>332.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897188" lon="-122.456496">
+        <time>2026-03-21T17:17:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.035</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897157" lon="-122.456498">
+        <time>2026-03-21T17:20:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.075</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897200" lon="-122.456499">
+        <time>2026-03-21T17:22:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.160</gpxtpx:speed>
+            <gpxtpx:course>15.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897183" lon="-122.456496">
+        <time>2026-03-21T17:25:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.072</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897287" lon="-122.456460">
+        <time>2026-03-21T17:28:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.051</gpxtpx:speed>
+            <gpxtpx:course>15.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897181" lon="-122.456495">
+        <time>2026-03-21T17:30:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.051</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897182" lon="-122.456474">
+        <time>2026-03-21T17:33:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.009</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897258" lon="-122.456429">
+        <time>2026-03-21T17:35:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.240</gpxtpx:speed>
+            <gpxtpx:course>349.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897204" lon="-122.456529">
+        <time>2026-03-21T17:38:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.024</gpxtpx:speed>
+            <gpxtpx:course>265.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897299" lon="-122.456564">
+        <time>2026-03-21T17:41:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.480</gpxtpx:speed>
+            <gpxtpx:course>293.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897250" lon="-122.456502">
+        <time>2026-03-21T17:43:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.510</gpxtpx:speed>
+            <gpxtpx:course>293.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897283" lon="-122.456525">
+        <time>2026-03-21T17:46:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.100</gpxtpx:speed>
+            <gpxtpx:course>293.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897269" lon="-122.456534">
+        <time>2026-03-21T17:48:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.050</gpxtpx:speed>
+            <gpxtpx:course>350.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897227" lon="-122.456512">
+        <time>2026-03-21T17:51:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.018</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897244" lon="-122.456508">
+        <time>2026-03-21T17:54:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897250" lon="-122.456540">
+        <time>2026-03-21T17:56:46Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.030</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897258" lon="-122.456508">
+        <time>2026-03-21T17:59:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.020</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897215" lon="-122.456522">
+        <time>2026-03-21T18:01:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.033</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897262" lon="-122.456543">
+        <time>2026-03-21T18:04:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.023</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.897314" lon="-122.456518">
+        <time>2026-03-21T18:21:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.064</gpxtpx:speed>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-03-26.gpx
+++ b/data/telemetry/tracks/2026-03-26.gpx
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-03-26</name>
+    <time>2026-03-26T23:36:53Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-03-26</name>
+    <trkseg>
+      <trkpt lat="37.783004" lon="-122.383055">
+        <time>2026-03-26T23:36:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.680</gpxtpx:speed>
+            <gpxtpx:course>58.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784255" lon="-122.378629">
+        <time>2026-03-26T23:39:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.810</gpxtpx:speed>
+            <gpxtpx:course>73.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785113" lon="-122.373744">
+        <time>2026-03-26T23:42:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.170</gpxtpx:speed>
+            <gpxtpx:course>60.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783680" lon="-122.374126">
+        <time>2026-03-26T23:44:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.383</gpxtpx:speed>
+            <gpxtpx:course>193.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784753" lon="-122.375977">
+        <time>2026-03-26T23:47:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.110</gpxtpx:speed>
+            <gpxtpx:course>308.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.787590" lon="-122.379265">
+        <time>2026-03-26T23:49:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.530</gpxtpx:speed>
+            <gpxtpx:course>324.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789791" lon="-122.381570">
+        <time>2026-03-26T23:52:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.905</gpxtpx:speed>
+            <gpxtpx:course>323.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.791150" lon="-122.382863">
+        <time>2026-03-26T23:55:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.210</gpxtpx:speed>
+            <gpxtpx:course>324.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.794486" lon="-122.385699">
+        <time>2026-03-26T23:57:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.949</gpxtpx:speed>
+            <gpxtpx:course>330.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-03-27.gpx
+++ b/data/telemetry/tracks/2026-03-27.gpx
@@ -1,0 +1,381 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-03-27</name>
+    <time>2026-03-27T00:00:15Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-03-27</name>
+    <trkseg>
+      <trkpt lat="37.797726" lon="-122.388279">
+        <time>2026-03-27T00:00:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.110</gpxtpx:speed>
+            <gpxtpx:course>335.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.801446" lon="-122.390793">
+        <time>2026-03-27T00:02:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.900</gpxtpx:speed>
+            <gpxtpx:course>335.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805058" lon="-122.392947">
+        <time>2026-03-27T00:05:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.950</gpxtpx:speed>
+            <gpxtpx:course>336.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.808709" lon="-122.395474">
+        <time>2026-03-27T00:08:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.391</gpxtpx:speed>
+            <gpxtpx:course>287.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.810819" lon="-122.399220">
+        <time>2026-03-27T00:10:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.479</gpxtpx:speed>
+            <gpxtpx:course>309.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.813187" lon="-122.401980">
+        <time>2026-03-27T00:13:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.656</gpxtpx:speed>
+            <gpxtpx:course>321.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815694" lon="-122.405032">
+        <time>2026-03-27T00:15:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.800</gpxtpx:speed>
+            <gpxtpx:course>320.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818158" lon="-122.408925">
+        <time>2026-03-27T00:18:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.890</gpxtpx:speed>
+            <gpxtpx:course>303.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820337" lon="-122.413181">
+        <time>2026-03-27T00:21:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.053</gpxtpx:speed>
+            <gpxtpx:course>219.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816557" lon="-122.413054">
+        <time>2026-03-27T00:23:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.214</gpxtpx:speed>
+            <gpxtpx:course>182.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814600" lon="-122.413255">
+        <time>2026-03-27T00:26:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.045</gpxtpx:speed>
+            <gpxtpx:course>323.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816445" lon="-122.416002">
+        <time>2026-03-27T00:28:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.335</gpxtpx:speed>
+            <gpxtpx:course>316.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818717" lon="-122.419210">
+        <time>2026-03-27T00:31:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.769</gpxtpx:speed>
+            <gpxtpx:course>312.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.821445" lon="-122.423258">
+        <time>2026-03-27T00:34:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.075</gpxtpx:speed>
+            <gpxtpx:course>311.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817827" lon="-122.422869">
+        <time>2026-03-27T00:36:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.093</gpxtpx:speed>
+            <gpxtpx:course>181.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.813897" lon="-122.423004">
+        <time>2026-03-27T00:39:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.877</gpxtpx:speed>
+            <gpxtpx:course>238.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815175" lon="-122.424793">
+        <time>2026-03-27T00:41:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.447</gpxtpx:speed>
+            <gpxtpx:course>313.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817554" lon="-122.427987">
+        <time>2026-03-27T00:44:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.050</gpxtpx:speed>
+            <gpxtpx:course>313.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820277" lon="-122.432720">
+        <time>2026-03-27T00:47:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.412</gpxtpx:speed>
+            <gpxtpx:course>303.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.822876" lon="-122.437270">
+        <time>2026-03-27T00:49:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.639</gpxtpx:speed>
+            <gpxtpx:course>302.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.824682" lon="-122.441472">
+        <time>2026-03-27T00:52:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.754</gpxtpx:speed>
+            <gpxtpx:course>290.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.826342" lon="-122.445776">
+        <time>2026-03-27T00:54:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.420</gpxtpx:speed>
+            <gpxtpx:course>293.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.827553" lon="-122.449476">
+        <time>2026-03-27T00:57:30Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.336</gpxtpx:speed>
+            <gpxtpx:course>302.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.827875" lon="-122.449763">
+        <time>2026-03-27T01:00:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.618</gpxtpx:speed>
+            <gpxtpx:course>109.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.826223" lon="-122.441766">
+        <time>2026-03-27T01:02:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.730</gpxtpx:speed>
+            <gpxtpx:course>106.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.824493" lon="-122.433907">
+        <time>2026-03-27T01:05:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.258</gpxtpx:speed>
+            <gpxtpx:course>106.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.822329" lon="-122.427255">
+        <time>2026-03-27T01:07:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.889</gpxtpx:speed>
+            <gpxtpx:course>120.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819894" lon="-122.421221">
+        <time>2026-03-27T01:10:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.299</gpxtpx:speed>
+            <gpxtpx:course>117.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817933" lon="-122.416005">
+        <time>2026-03-27T01:13:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.678</gpxtpx:speed>
+            <gpxtpx:course>111.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816041" lon="-122.410000">
+        <time>2026-03-27T01:15:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.474</gpxtpx:speed>
+            <gpxtpx:course>111.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814033" lon="-122.404436">
+        <time>2026-03-27T01:18:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.299</gpxtpx:speed>
+            <gpxtpx:course>111.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.811822" lon="-122.399318">
+        <time>2026-03-27T01:20:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.125</gpxtpx:speed>
+            <gpxtpx:course>119.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809028" lon="-122.394651">
+        <time>2026-03-27T01:23:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.429</gpxtpx:speed>
+            <gpxtpx:course>132.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805179" lon="-122.390692">
+        <time>2026-03-27T01:26:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.804</gpxtpx:speed>
+            <gpxtpx:course>146.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.800627" lon="-122.386852">
+        <time>2026-03-27T01:28:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.060</gpxtpx:speed>
+            <gpxtpx:course>147.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.795860" lon="-122.383452">
+        <time>2026-03-27T01:31:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.500</gpxtpx:speed>
+            <gpxtpx:course>148.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.792752" lon="-122.381219">
+        <time>2026-03-27T01:33:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.240</gpxtpx:speed>
+            <gpxtpx:course>148.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.787667" lon="-122.376985">
+        <time>2026-03-27T01:36:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.330</gpxtpx:speed>
+            <gpxtpx:course>155.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784656" lon="-122.376998">
+        <time>2026-03-27T01:39:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.289</gpxtpx:speed>
+            <gpxtpx:course>197.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782996" lon="-122.377617">
+        <time>2026-03-27T01:41:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.523</gpxtpx:speed>
+            <gpxtpx:course>207.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782980" lon="-122.383024">
+        <time>2026-03-27T01:44:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.490</gpxtpx:speed>
+            <gpxtpx:course>260.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-04-04.gpx
+++ b/data/telemetry/tracks/2026-04-04.gpx
@@ -1,0 +1,750 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-04-04</name>
+    <time>2026-04-04T20:28:17Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-04-04</name>
+    <trkseg>
+      <trkpt lat="37.782723" lon="-122.383875">
+        <time>2026-04-04T20:28:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.900</gpxtpx:speed>
+            <gpxtpx:course>44.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785183" lon="-122.381598">
+        <time>2026-04-04T20:30:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.719</gpxtpx:speed>
+            <gpxtpx:course>2.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.787771" lon="-122.381436">
+        <time>2026-04-04T20:33:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.824</gpxtpx:speed>
+            <gpxtpx:course>359.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.791774" lon="-122.382229">
+        <time>2026-04-04T20:36:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.050</gpxtpx:speed>
+            <gpxtpx:course>343.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.795822" lon="-122.383554">
+        <time>2026-04-04T20:38:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.850</gpxtpx:speed>
+            <gpxtpx:course>349.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.799911" lon="-122.384324">
+        <time>2026-04-04T20:41:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.928</gpxtpx:speed>
+            <gpxtpx:course>348.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.803688" lon="-122.384588">
+        <time>2026-04-04T20:43:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.790</gpxtpx:speed>
+            <gpxtpx:course>357.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806803" lon="-122.387659">
+        <time>2026-04-04T20:46:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.651</gpxtpx:speed>
+            <gpxtpx:course>328.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.810336" lon="-122.390561">
+        <time>2026-04-04T20:49:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.420</gpxtpx:speed>
+            <gpxtpx:course>324.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814164" lon="-122.393431">
+        <time>2026-04-04T20:51:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.287</gpxtpx:speed>
+            <gpxtpx:course>340.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818642" lon="-122.394460">
+        <time>2026-04-04T20:54:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.118</gpxtpx:speed>
+            <gpxtpx:course>340.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819738" lon="-122.399464">
+        <time>2026-04-04T20:56:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.109</gpxtpx:speed>
+            <gpxtpx:course>268.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820000" lon="-122.404800">
+        <time>2026-04-04T20:59:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.020</gpxtpx:speed>
+            <gpxtpx:course>271.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819793" lon="-122.410136">
+        <time>2026-04-04T21:02:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.827</gpxtpx:speed>
+            <gpxtpx:course>268.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817317" lon="-122.414274">
+        <time>2026-04-04T21:04:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.215</gpxtpx:speed>
+            <gpxtpx:course>254.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818070" lon="-122.419984">
+        <time>2026-04-04T21:07:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.600</gpxtpx:speed>
+            <gpxtpx:course>287.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819957" lon="-122.425187">
+        <time>2026-04-04T21:09:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.290</gpxtpx:speed>
+            <gpxtpx:course>295.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.822603" lon="-122.429987">
+        <time>2026-04-04T21:12:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.393</gpxtpx:speed>
+            <gpxtpx:course>313.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.824927" lon="-122.431842">
+        <time>2026-04-04T21:15:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.906</gpxtpx:speed>
+            <gpxtpx:course>37.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.826155" lon="-122.431284">
+        <time>2026-04-04T21:17:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.199</gpxtpx:speed>
+            <gpxtpx:course>301.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.828053" lon="-122.433325">
+        <time>2026-04-04T21:20:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.905</gpxtpx:speed>
+            <gpxtpx:course>319.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.828937" lon="-122.434258">
+        <time>2026-04-04T21:22:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.664</gpxtpx:speed>
+            <gpxtpx:course>299.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.828949" lon="-122.435349">
+        <time>2026-04-04T21:25:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.600</gpxtpx:speed>
+            <gpxtpx:course>265.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.829659" lon="-122.436173">
+        <time>2026-04-04T21:28:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.830</gpxtpx:speed>
+            <gpxtpx:course>336.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.830250" lon="-122.437076">
+        <time>2026-04-04T21:30:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.463</gpxtpx:speed>
+            <gpxtpx:course>303.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.830975" lon="-122.438227">
+        <time>2026-04-04T21:33:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.847</gpxtpx:speed>
+            <gpxtpx:course>294.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.831885" lon="-122.441526">
+        <time>2026-04-04T21:35:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.690</gpxtpx:speed>
+            <gpxtpx:course>282.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.833490" lon="-122.441785">
+        <time>2026-04-04T21:38:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.565</gpxtpx:speed>
+            <gpxtpx:course>63.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.835227" lon="-122.437302">
+        <time>2026-04-04T21:41:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.858</gpxtpx:speed>
+            <gpxtpx:course>63.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.836936" lon="-122.433449">
+        <time>2026-04-04T21:43:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.020</gpxtpx:speed>
+            <gpxtpx:course>66.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.837984" lon="-122.430256">
+        <time>2026-04-04T21:46:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.671</gpxtpx:speed>
+            <gpxtpx:course>66.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.838931" lon="-122.427787">
+        <time>2026-04-04T21:48:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.450</gpxtpx:speed>
+            <gpxtpx:course>66.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.841301" lon="-122.424200">
+        <time>2026-04-04T21:51:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.494</gpxtpx:speed>
+            <gpxtpx:course>50.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.844254" lon="-122.419877">
+        <time>2026-04-04T21:54:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.751</gpxtpx:speed>
+            <gpxtpx:course>49.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.846665" lon="-122.415965">
+        <time>2026-04-04T21:56:46Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.064</gpxtpx:speed>
+            <gpxtpx:course>60.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.848732" lon="-122.411613">
+        <time>2026-04-04T21:59:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.200</gpxtpx:speed>
+            <gpxtpx:course>59.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.851467" lon="-122.408404">
+        <time>2026-04-04T22:01:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.098</gpxtpx:speed>
+            <gpxtpx:course>36.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.855678" lon="-122.405456">
+        <time>2026-04-04T22:04:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.768</gpxtpx:speed>
+            <gpxtpx:course>22.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.861081" lon="-122.403613">
+        <time>2026-04-04T22:07:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.140</gpxtpx:speed>
+            <gpxtpx:course>7.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.866612" lon="-122.402975">
+        <time>2026-04-04T22:09:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.810</gpxtpx:speed>
+            <gpxtpx:course>2.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.872075" lon="-122.402671">
+        <time>2026-04-04T22:12:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.020</gpxtpx:speed>
+            <gpxtpx:course>1.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.877542" lon="-122.401898">
+        <time>2026-04-04T22:14:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.070</gpxtpx:speed>
+            <gpxtpx:course>7.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.877699" lon="-122.405779">
+        <time>2026-04-04T22:17:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.241</gpxtpx:speed>
+            <gpxtpx:course>259.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.877821" lon="-122.410407">
+        <time>2026-04-04T22:20:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.650</gpxtpx:speed>
+            <gpxtpx:course>272.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.878053" lon="-122.414871">
+        <time>2026-04-04T22:22:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.483</gpxtpx:speed>
+            <gpxtpx:course>284.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.878299" lon="-122.419188">
+        <time>2026-04-04T22:25:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.211</gpxtpx:speed>
+            <gpxtpx:course>275.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.878575" lon="-122.423903">
+        <time>2026-04-04T22:27:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.763</gpxtpx:speed>
+            <gpxtpx:course>273.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.878600" lon="-122.428556">
+        <time>2026-04-04T22:30:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.930</gpxtpx:speed>
+            <gpxtpx:course>267.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.879003" lon="-122.433137">
+        <time>2026-04-04T22:33:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.810</gpxtpx:speed>
+            <gpxtpx:course>27.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.880602" lon="-122.428667">
+        <time>2026-04-04T22:35:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.560</gpxtpx:speed>
+            <gpxtpx:course>76.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.881913" lon="-122.424199">
+        <time>2026-04-04T22:38:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.748</gpxtpx:speed>
+            <gpxtpx:course>70.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.883494" lon="-122.419648">
+        <time>2026-04-04T22:41:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.851</gpxtpx:speed>
+            <gpxtpx:course>74.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.883654" lon="-122.415879">
+        <time>2026-04-04T22:43:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.854</gpxtpx:speed>
+            <gpxtpx:course>85.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.884519" lon="-122.412044">
+        <time>2026-04-04T22:46:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.850</gpxtpx:speed>
+            <gpxtpx:course>65.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.884832" lon="-122.408405">
+        <time>2026-04-04T22:48:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.900</gpxtpx:speed>
+            <gpxtpx:course>123.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.883540" lon="-122.405464">
+        <time>2026-04-04T22:51:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.942</gpxtpx:speed>
+            <gpxtpx:course>114.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.882169" lon="-122.402502">
+        <time>2026-04-04T22:54:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.056</gpxtpx:speed>
+            <gpxtpx:course>125.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.880941" lon="-122.399483">
+        <time>2026-04-04T22:56:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.863</gpxtpx:speed>
+            <gpxtpx:course>106.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.879736" lon="-122.396409">
+        <time>2026-04-04T22:59:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.960</gpxtpx:speed>
+            <gpxtpx:course>127.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.878192" lon="-122.393328">
+        <time>2026-04-04T23:01:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.040</gpxtpx:speed>
+            <gpxtpx:course>122.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.875473" lon="-122.391967">
+        <time>2026-04-04T23:04:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.024</gpxtpx:speed>
+            <gpxtpx:course>188.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.871140" lon="-122.392113">
+        <time>2026-04-04T23:07:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.028</gpxtpx:speed>
+            <gpxtpx:course>175.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.866824" lon="-122.392271">
+        <time>2026-04-04T23:09:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.011</gpxtpx:speed>
+            <gpxtpx:course>183.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.862564" lon="-122.392592">
+        <time>2026-04-04T23:12:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.766</gpxtpx:speed>
+            <gpxtpx:course>176.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.858819" lon="-122.392586">
+        <time>2026-04-04T23:14:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.704</gpxtpx:speed>
+            <gpxtpx:course>181.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.855098" lon="-122.392886">
+        <time>2026-04-04T23:17:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.325</gpxtpx:speed>
+            <gpxtpx:course>173.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.851816" lon="-122.392706">
+        <time>2026-04-04T23:20:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.472</gpxtpx:speed>
+            <gpxtpx:course>186.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.848618" lon="-122.392413">
+        <time>2026-04-04T23:22:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.490</gpxtpx:speed>
+            <gpxtpx:course>178.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.845382" lon="-122.391971">
+        <time>2026-04-04T23:25:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.277</gpxtpx:speed>
+            <gpxtpx:course>175.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.842196" lon="-122.391667">
+        <time>2026-04-04T23:27:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.320</gpxtpx:speed>
+            <gpxtpx:course>176.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.839045" lon="-122.391712">
+        <time>2026-04-04T23:30:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.119</gpxtpx:speed>
+            <gpxtpx:course>184.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.836011" lon="-122.391916">
+        <time>2026-04-04T23:33:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.110</gpxtpx:speed>
+            <gpxtpx:course>178.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.833377" lon="-122.391980">
+        <time>2026-04-04T23:35:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.550</gpxtpx:speed>
+            <gpxtpx:course>182.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.831458" lon="-122.391859">
+        <time>2026-04-04T23:38:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.270</gpxtpx:speed>
+            <gpxtpx:course>176.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.829725" lon="-122.391594">
+        <time>2026-04-04T23:40:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.270</gpxtpx:speed>
+            <gpxtpx:course>184.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.827757" lon="-122.391755">
+        <time>2026-04-04T23:43:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.070</gpxtpx:speed>
+            <gpxtpx:course>170.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.826555" lon="-122.391701">
+        <time>2026-04-04T23:46:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.782</gpxtpx:speed>
+            <gpxtpx:course>137.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.825421" lon="-122.390654">
+        <time>2026-04-04T23:48:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.100</gpxtpx:speed>
+            <gpxtpx:course>146.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.823979" lon="-122.389582">
+        <time>2026-04-04T23:51:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.253</gpxtpx:speed>
+            <gpxtpx:course>142.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.822358" lon="-122.388512">
+        <time>2026-04-04T23:53:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.390</gpxtpx:speed>
+            <gpxtpx:course>152.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.820757" lon="-122.387472">
+        <time>2026-04-04T23:56:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.250</gpxtpx:speed>
+            <gpxtpx:course>152.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.819116" lon="-122.386482">
+        <time>2026-04-04T23:59:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.310</gpxtpx:speed>
+            <gpxtpx:course>151.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-04-05.gpx
+++ b/data/telemetry/tracks/2026-04-05.gpx
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-04-05</name>
+    <time>2026-04-05T00:01:39Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-04-05</name>
+    <trkseg>
+      <trkpt lat="37.817537" lon="-122.385493">
+        <time>2026-04-05T00:01:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.182</gpxtpx:speed>
+            <gpxtpx:course>151.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816023" lon="-122.384559">
+        <time>2026-04-05T00:04:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.239</gpxtpx:speed>
+            <gpxtpx:course>158.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814395" lon="-122.383652">
+        <time>2026-04-05T00:06:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.320</gpxtpx:speed>
+            <gpxtpx:course>166.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.813028" lon="-122.382450">
+        <time>2026-04-05T00:09:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.140</gpxtpx:speed>
+            <gpxtpx:course>143.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.812165" lon="-122.381442">
+        <time>2026-04-05T00:12:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.300</gpxtpx:speed>
+            <gpxtpx:course>216.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.811058" lon="-122.382563">
+        <time>2026-04-05T00:14:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.740</gpxtpx:speed>
+            <gpxtpx:course>227.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809987" lon="-122.383437">
+        <time>2026-04-05T00:17:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.922</gpxtpx:speed>
+            <gpxtpx:course>207.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.808854" lon="-122.384294">
+        <time>2026-04-05T00:19:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.992</gpxtpx:speed>
+            <gpxtpx:course>211.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.806161" lon="-122.385031">
+        <time>2026-04-05T00:22:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.186</gpxtpx:speed>
+            <gpxtpx:course>191.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.802188" lon="-122.385234">
+        <time>2026-04-05T00:25:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.203</gpxtpx:speed>
+            <gpxtpx:course>201.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.798221" lon="-122.385386">
+        <time>2026-04-05T00:27:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.739</gpxtpx:speed>
+            <gpxtpx:course>174.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.794133" lon="-122.384406">
+        <time>2026-04-05T00:30:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.123</gpxtpx:speed>
+            <gpxtpx:course>161.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789979" lon="-122.382540">
+        <time>2026-04-05T00:32:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.230</gpxtpx:speed>
+            <gpxtpx:course>169.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789516" lon="-122.381753">
+        <time>2026-04-05T00:35:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.816</gpxtpx:speed>
+            <gpxtpx:course>344.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.789165" lon="-122.382131">
+        <time>2026-04-05T00:38:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.547</gpxtpx:speed>
+            <gpxtpx:course>182.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.786366" lon="-122.383282">
+        <time>2026-04-05T00:40:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.045</gpxtpx:speed>
+            <gpxtpx:course>202.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782910" lon="-122.384398">
+        <time>2026-04-05T00:43:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.350</gpxtpx:speed>
+            <gpxtpx:course>197.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-04-11.gpx
+++ b/data/telemetry/tracks/2026-04-11.gpx
@@ -1,0 +1,1641 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-04-11</name>
+    <time>2026-04-11T14:37:09Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-04-11</name>
+    <trkseg>
+      <trkpt lat="37.783050" lon="-122.384154">
+        <time>2026-04-11T14:37:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.294</gpxtpx:speed>
+            <gpxtpx:course>15.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788919" lon="-122.383142">
+        <time>2026-04-11T14:39:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.324</gpxtpx:speed>
+            <gpxtpx:course>1.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.794414" lon="-122.385492">
+        <time>2026-04-11T14:42:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.860</gpxtpx:speed>
+            <gpxtpx:course>330.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.799537" lon="-122.388462">
+        <time>2026-04-11T14:44:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.911</gpxtpx:speed>
+            <gpxtpx:course>333.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804350" lon="-122.392242">
+        <time>2026-04-11T14:47:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.780</gpxtpx:speed>
+            <gpxtpx:course>320.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809095" lon="-122.396755">
+        <time>2026-04-11T14:50:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.381</gpxtpx:speed>
+            <gpxtpx:course>322.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.813469" lon="-122.402039">
+        <time>2026-04-11T14:52:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.390</gpxtpx:speed>
+            <gpxtpx:course>304.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816569" lon="-122.408783">
+        <time>2026-04-11T14:55:18Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.402</gpxtpx:speed>
+            <gpxtpx:course>293.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818599" lon="-122.416191">
+        <time>2026-04-11T14:57:54Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.371</gpxtpx:speed>
+            <gpxtpx:course>287.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.818522" lon="-122.423592">
+        <time>2026-04-11T15:00:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.215</gpxtpx:speed>
+            <gpxtpx:course>263.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817397" lon="-122.430800">
+        <time>2026-04-11T15:03:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.030</gpxtpx:speed>
+            <gpxtpx:course>262.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.817369" lon="-122.437717">
+        <time>2026-04-11T15:05:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.344</gpxtpx:speed>
+            <gpxtpx:course>275.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814783" lon="-122.437929">
+        <time>2026-04-11T15:08:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.859</gpxtpx:speed>
+            <gpxtpx:course>176.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.813551" lon="-122.438395">
+        <time>2026-04-11T15:10:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.410</gpxtpx:speed>
+            <gpxtpx:course>317.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815021" lon="-122.442418">
+        <time>2026-04-11T15:13:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.477</gpxtpx:speed>
+            <gpxtpx:course>276.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.813829" lon="-122.444369">
+        <time>2026-04-11T15:16:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.030</gpxtpx:speed>
+            <gpxtpx:course>181.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.812561" lon="-122.444919">
+        <time>2026-04-11T15:18:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.071</gpxtpx:speed>
+            <gpxtpx:course>205.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.812597" lon="-122.446236">
+        <time>2026-04-11T15:21:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.712</gpxtpx:speed>
+            <gpxtpx:course>341.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816778" lon="-122.448156">
+        <time>2026-04-11T15:23:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.604</gpxtpx:speed>
+            <gpxtpx:course>10.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816255" lon="-122.448150">
+        <time>2026-04-11T15:26:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.193</gpxtpx:speed>
+            <gpxtpx:course>195.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815062" lon="-122.448109">
+        <time>2026-04-11T15:29:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.649</gpxtpx:speed>
+            <gpxtpx:course>112.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815089" lon="-122.445280">
+        <time>2026-04-11T15:31:41Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.680</gpxtpx:speed>
+            <gpxtpx:course>55.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815023" lon="-122.442417">
+        <time>2026-04-11T15:34:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.766</gpxtpx:speed>
+            <gpxtpx:course>116.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814640" lon="-122.439588">
+        <time>2026-04-11T15:36:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.974</gpxtpx:speed>
+            <gpxtpx:course>98.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.813322" lon="-122.436472">
+        <time>2026-04-11T15:39:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.195</gpxtpx:speed>
+            <gpxtpx:course>133.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.811025" lon="-122.435276">
+        <time>2026-04-11T15:42:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.749</gpxtpx:speed>
+            <gpxtpx:course>257.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.810823" lon="-122.439441">
+        <time>2026-04-11T15:44:40Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.270</gpxtpx:speed>
+            <gpxtpx:course>258.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.810935" lon="-122.446063">
+        <time>2026-04-11T15:47:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.054</gpxtpx:speed>
+            <gpxtpx:course>271.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.812050" lon="-122.453165">
+        <time>2026-04-11T15:49:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.210</gpxtpx:speed>
+            <gpxtpx:course>283.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.813245" lon="-122.460539">
+        <time>2026-04-11T15:52:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.170</gpxtpx:speed>
+            <gpxtpx:course>284.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814449" lon="-122.467931">
+        <time>2026-04-11T15:55:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.490</gpxtpx:speed>
+            <gpxtpx:course>280.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815639" lon="-122.474989">
+        <time>2026-04-11T15:57:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.620</gpxtpx:speed>
+            <gpxtpx:course>275.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815305" lon="-122.482087">
+        <time>2026-04-11T16:00:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.069</gpxtpx:speed>
+            <gpxtpx:course>259.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814181" lon="-122.489118">
+        <time>2026-04-11T16:02:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.990</gpxtpx:speed>
+            <gpxtpx:course>250.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.812721" lon="-122.495687">
+        <time>2026-04-11T16:05:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.790</gpxtpx:speed>
+            <gpxtpx:course>257.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.811416" lon="-122.501833">
+        <time>2026-04-11T16:08:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.318</gpxtpx:speed>
+            <gpxtpx:course>190.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.810026" lon="-122.505578">
+        <time>2026-04-11T16:10:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.565</gpxtpx:speed>
+            <gpxtpx:course>262.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.808798" lon="-122.511309">
+        <time>2026-04-11T16:13:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.140</gpxtpx:speed>
+            <gpxtpx:course>248.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.807586" lon="-122.516929">
+        <time>2026-04-11T16:15:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.970</gpxtpx:speed>
+            <gpxtpx:course>264.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805869" lon="-122.522462">
+        <time>2026-04-11T16:18:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.980</gpxtpx:speed>
+            <gpxtpx:course>243.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.803443" lon="-122.528852">
+        <time>2026-04-11T16:21:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.997</gpxtpx:speed>
+            <gpxtpx:course>247.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.801388" lon="-122.535958">
+        <time>2026-04-11T16:23:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.320</gpxtpx:speed>
+            <gpxtpx:course>254.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.799547" lon="-122.543015">
+        <time>2026-04-11T16:26:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.450</gpxtpx:speed>
+            <gpxtpx:course>258.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.797692" lon="-122.549995">
+        <time>2026-04-11T16:28:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.010</gpxtpx:speed>
+            <gpxtpx:course>240.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.795786" lon="-122.556758">
+        <time>2026-04-11T16:31:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.740</gpxtpx:speed>
+            <gpxtpx:course>245.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.793987" lon="-122.563721">
+        <time>2026-04-11T16:34:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.360</gpxtpx:speed>
+            <gpxtpx:course>249.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.791974" lon="-122.570242">
+        <time>2026-04-11T16:36:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.587</gpxtpx:speed>
+            <gpxtpx:course>236.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.790102" lon="-122.576293">
+        <time>2026-04-11T16:39:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.910</gpxtpx:speed>
+            <gpxtpx:course>250.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788296" lon="-122.583426">
+        <time>2026-04-11T16:41:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.649</gpxtpx:speed>
+            <gpxtpx:course>260.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.786837" lon="-122.590884">
+        <time>2026-04-11T16:44:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.234</gpxtpx:speed>
+            <gpxtpx:course>256.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785221" lon="-122.598122">
+        <time>2026-04-11T16:47:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.269</gpxtpx:speed>
+            <gpxtpx:course>255.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783448" lon="-122.605315">
+        <time>2026-04-11T16:49:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.930</gpxtpx:speed>
+            <gpxtpx:course>258.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781550" lon="-122.612101">
+        <time>2026-04-11T16:52:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.555</gpxtpx:speed>
+            <gpxtpx:course>255.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.780034" lon="-122.619081">
+        <time>2026-04-11T16:54:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.191</gpxtpx:speed>
+            <gpxtpx:course>251.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.777932" lon="-122.625604">
+        <time>2026-04-11T16:57:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.269</gpxtpx:speed>
+            <gpxtpx:course>245.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.775805" lon="-122.631937">
+        <time>2026-04-11T17:00:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.691</gpxtpx:speed>
+            <gpxtpx:course>250.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.773246" lon="-122.637843">
+        <time>2026-04-11T17:02:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.586</gpxtpx:speed>
+            <gpxtpx:course>231.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.770200" lon="-122.643496">
+        <time>2026-04-11T17:05:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.640</gpxtpx:speed>
+            <gpxtpx:course>236.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.767691" lon="-122.649773">
+        <time>2026-04-11T17:07:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.810</gpxtpx:speed>
+            <gpxtpx:course>228.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.765422" lon="-122.656346">
+        <time>2026-04-11T17:10:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.880</gpxtpx:speed>
+            <gpxtpx:course>246.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.762904" lon="-122.662646">
+        <time>2026-04-11T17:13:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.057</gpxtpx:speed>
+            <gpxtpx:course>242.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.761244" lon="-122.669500">
+        <time>2026-04-11T17:15:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.870</gpxtpx:speed>
+            <gpxtpx:course>254.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.759872" lon="-122.676415">
+        <time>2026-04-11T17:18:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.110</gpxtpx:speed>
+            <gpxtpx:course>258.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.758660" lon="-122.683445">
+        <time>2026-04-11T17:20:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.910</gpxtpx:speed>
+            <gpxtpx:course>253.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.757195" lon="-122.690301">
+        <time>2026-04-11T17:23:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.370</gpxtpx:speed>
+            <gpxtpx:course>263.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.756381" lon="-122.698014">
+        <time>2026-04-11T17:26:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.700</gpxtpx:speed>
+            <gpxtpx:course>277.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.756565" lon="-122.705305">
+        <time>2026-04-11T17:29:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.040</gpxtpx:speed>
+            <gpxtpx:course>271.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.756130" lon="-122.711843">
+        <time>2026-04-11T17:31:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.576</gpxtpx:speed>
+            <gpxtpx:course>264.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.755490" lon="-122.725053">
+        <time>2026-04-11T17:37:11Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.247</gpxtpx:speed>
+            <gpxtpx:course>278.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.755349" lon="-122.731630">
+        <time>2026-04-11T17:39:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.781</gpxtpx:speed>
+            <gpxtpx:course>269.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.754393" lon="-122.737928">
+        <time>2026-04-11T17:42:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.650</gpxtpx:speed>
+            <gpxtpx:course>256.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.753130" lon="-122.743848">
+        <time>2026-04-11T17:44:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.177</gpxtpx:speed>
+            <gpxtpx:course>262.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.751888" lon="-122.749825">
+        <time>2026-04-11T17:47:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.716</gpxtpx:speed>
+            <gpxtpx:course>256.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.750580" lon="-122.755984">
+        <time>2026-04-11T17:50:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.347</gpxtpx:speed>
+            <gpxtpx:course>257.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.749496" lon="-122.761977">
+        <time>2026-04-11T17:52:46Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.705</gpxtpx:speed>
+            <gpxtpx:course>253.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.748091" lon="-122.767600">
+        <time>2026-04-11T17:55:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.680</gpxtpx:speed>
+            <gpxtpx:course>253.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.746645" lon="-122.773615">
+        <time>2026-04-11T17:57:58Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.395</gpxtpx:speed>
+            <gpxtpx:course>247.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.745169" lon="-122.779708">
+        <time>2026-04-11T18:00:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.549</gpxtpx:speed>
+            <gpxtpx:course>258.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.743560" lon="-122.785556">
+        <time>2026-04-11T18:03:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.336</gpxtpx:speed>
+            <gpxtpx:course>237.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.741920" lon="-122.791317">
+        <time>2026-04-11T18:05:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.820</gpxtpx:speed>
+            <gpxtpx:course>252.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.740288" lon="-122.797226">
+        <time>2026-04-11T18:08:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.320</gpxtpx:speed>
+            <gpxtpx:course>247.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.738419" lon="-122.802948">
+        <time>2026-04-11T18:11:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.222</gpxtpx:speed>
+            <gpxtpx:course>243.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.736541" lon="-122.808798">
+        <time>2026-04-11T18:13:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.117</gpxtpx:speed>
+            <gpxtpx:course>238.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.734436" lon="-122.814690">
+        <time>2026-04-11T18:16:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.480</gpxtpx:speed>
+            <gpxtpx:course>238.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.732499" lon="-122.820333">
+        <time>2026-04-11T18:18:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.275</gpxtpx:speed>
+            <gpxtpx:course>241.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.730409" lon="-122.825473">
+        <time>2026-04-11T18:21:31Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.070</gpxtpx:speed>
+            <gpxtpx:course>240.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.729409" lon="-122.831540">
+        <time>2026-04-11T18:24:08Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.260</gpxtpx:speed>
+            <gpxtpx:course>260.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.729398" lon="-122.836877">
+        <time>2026-04-11T18:26:44Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.432</gpxtpx:speed>
+            <gpxtpx:course>272.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.729465" lon="-122.842713">
+        <time>2026-04-11T18:29:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.403</gpxtpx:speed>
+            <gpxtpx:course>268.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.728586" lon="-122.847532">
+        <time>2026-04-11T18:31:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.879</gpxtpx:speed>
+            <gpxtpx:course>248.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.727523" lon="-122.852842">
+        <time>2026-04-11T18:34:32Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.062</gpxtpx:speed>
+            <gpxtpx:course>246.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.726086" lon="-122.858090">
+        <time>2026-04-11T18:37:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.920</gpxtpx:speed>
+            <gpxtpx:course>248.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.724355" lon="-122.863118">
+        <time>2026-04-11T18:39:46Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.866</gpxtpx:speed>
+            <gpxtpx:course>245.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.722201" lon="-122.868050">
+        <time>2026-04-11T18:42:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.172</gpxtpx:speed>
+            <gpxtpx:course>223.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.720036" lon="-122.872956">
+        <time>2026-04-11T18:44:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.747</gpxtpx:speed>
+            <gpxtpx:course>238.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.717863" lon="-122.878247">
+        <time>2026-04-11T18:47:38Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.511</gpxtpx:speed>
+            <gpxtpx:course>242.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.715693" lon="-122.883535">
+        <time>2026-04-11T18:50:17Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.240</gpxtpx:speed>
+            <gpxtpx:course>249.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.713537" lon="-122.888698">
+        <time>2026-04-11T18:52:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.266</gpxtpx:speed>
+            <gpxtpx:course>249.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.711398" lon="-122.894467">
+        <time>2026-04-11T18:55:42Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.544</gpxtpx:speed>
+            <gpxtpx:course>249.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.709046" lon="-122.900081">
+        <time>2026-04-11T18:58:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.769</gpxtpx:speed>
+            <gpxtpx:course>239.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.706971" lon="-122.906231">
+        <time>2026-04-11T19:00:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.600</gpxtpx:speed>
+            <gpxtpx:course>238.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.704781" lon="-122.912209">
+        <time>2026-04-11T19:03:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.593</gpxtpx:speed>
+            <gpxtpx:course>238.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.702796" lon="-122.917925">
+        <time>2026-04-11T19:06:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.700</gpxtpx:speed>
+            <gpxtpx:course>235.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.700625" lon="-122.923995">
+        <time>2026-04-11T19:08:47Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.751</gpxtpx:speed>
+            <gpxtpx:course>245.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.698071" lon="-122.929722">
+        <time>2026-04-11T19:11:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.770</gpxtpx:speed>
+            <gpxtpx:course>245.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.695726" lon="-122.935512">
+        <time>2026-04-11T19:14:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.681</gpxtpx:speed>
+            <gpxtpx:course>245.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.693618" lon="-122.941882">
+        <time>2026-04-11T19:16:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.150</gpxtpx:speed>
+            <gpxtpx:course>245.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.691599" lon="-122.948022">
+        <time>2026-04-11T19:19:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.108</gpxtpx:speed>
+            <gpxtpx:course>254.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.689368" lon="-122.954647">
+        <time>2026-04-11T19:22:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.354</gpxtpx:speed>
+            <gpxtpx:course>247.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.682430" lon="-122.972733">
+        <time>2026-04-11T19:30:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.761</gpxtpx:speed>
+            <gpxtpx:course>239.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.736530" lon="-122.867084">
+        <time>2026-04-11T20:49:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.590</gpxtpx:speed>
+            <gpxtpx:course>85.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.738177" lon="-122.859024">
+        <time>2026-04-11T20:51:55Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.220</gpxtpx:speed>
+            <gpxtpx:course>89.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.739360" lon="-122.851198">
+        <time>2026-04-11T20:54:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.670</gpxtpx:speed>
+            <gpxtpx:course>80.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.742966" lon="-122.834377">
+        <time>2026-04-11T21:00:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.047</gpxtpx:speed>
+            <gpxtpx:course>77.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.744498" lon="-122.826065">
+        <time>2026-04-11T21:03:14Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.473</gpxtpx:speed>
+            <gpxtpx:course>78.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.746253" lon="-122.818285">
+        <time>2026-04-11T21:05:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.424</gpxtpx:speed>
+            <gpxtpx:course>75.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.748024" lon="-122.810601">
+        <time>2026-04-11T21:08:35Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.340</gpxtpx:speed>
+            <gpxtpx:course>73.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.749647" lon="-122.802874">
+        <time>2026-04-11T21:11:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.860</gpxtpx:speed>
+            <gpxtpx:course>68.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.751711" lon="-122.795002">
+        <time>2026-04-11T21:13:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.090</gpxtpx:speed>
+            <gpxtpx:course>71.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.753360" lon="-122.787536">
+        <time>2026-04-11T21:16:34Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.887</gpxtpx:speed>
+            <gpxtpx:course>81.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.755250" lon="-122.780041">
+        <time>2026-04-11T21:19:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.540</gpxtpx:speed>
+            <gpxtpx:course>73.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.757024" lon="-122.772518">
+        <time>2026-04-11T21:21:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.280</gpxtpx:speed>
+            <gpxtpx:course>70.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.758760" lon="-122.764897">
+        <time>2026-04-11T21:24:27Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.369</gpxtpx:speed>
+            <gpxtpx:course>67.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.760514" lon="-122.757170">
+        <time>2026-04-11T21:27:04Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.338</gpxtpx:speed>
+            <gpxtpx:course>70.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.762264" lon="-122.748980">
+        <time>2026-04-11T21:29:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.727</gpxtpx:speed>
+            <gpxtpx:course>84.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.763966" lon="-122.740932">
+        <time>2026-04-11T21:32:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.730</gpxtpx:speed>
+            <gpxtpx:course>76.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.765726" lon="-122.733133">
+        <time>2026-04-11T21:35:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.393</gpxtpx:speed>
+            <gpxtpx:course>71.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.767458" lon="-122.725367">
+        <time>2026-04-11T21:37:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.117</gpxtpx:speed>
+            <gpxtpx:course>74.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.769026" lon="-122.717935">
+        <time>2026-04-11T21:40:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.777</gpxtpx:speed>
+            <gpxtpx:course>75.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.770270" lon="-122.710604">
+        <time>2026-04-11T21:43:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.522</gpxtpx:speed>
+            <gpxtpx:course>81.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.771810" lon="-122.703416">
+        <time>2026-04-11T21:45:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.927</gpxtpx:speed>
+            <gpxtpx:course>68.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.773048" lon="-122.696248">
+        <time>2026-04-11T21:48:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.479</gpxtpx:speed>
+            <gpxtpx:course>80.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.774414" lon="-122.689111">
+        <time>2026-04-11T21:50:48Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.955</gpxtpx:speed>
+            <gpxtpx:course>78.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.775765" lon="-122.681944">
+        <time>2026-04-11T21:53:24Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.071</gpxtpx:speed>
+            <gpxtpx:course>67.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.777560" lon="-122.674479">
+        <time>2026-04-11T21:56:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.320</gpxtpx:speed>
+            <gpxtpx:course>71.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.778893" lon="-122.667102">
+        <time>2026-04-11T21:58:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.470</gpxtpx:speed>
+            <gpxtpx:course>83.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.780157" lon="-122.659589">
+        <time>2026-04-11T22:01:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.680</gpxtpx:speed>
+            <gpxtpx:course>82.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.781789" lon="-122.652006">
+        <time>2026-04-11T22:03:52Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.850</gpxtpx:speed>
+            <gpxtpx:course>74.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.783391" lon="-122.644425">
+        <time>2026-04-11T22:06:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.970</gpxtpx:speed>
+            <gpxtpx:course>81.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.784676" lon="-122.637395">
+        <time>2026-04-11T22:09:07Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.350</gpxtpx:speed>
+            <gpxtpx:course>68.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.785756" lon="-122.630267">
+        <time>2026-04-11T22:11:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.432</gpxtpx:speed>
+            <gpxtpx:course>77.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.787252" lon="-122.623246">
+        <time>2026-04-11T22:14:20Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.396</gpxtpx:speed>
+            <gpxtpx:course>93.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.788967" lon="-122.616684">
+        <time>2026-04-11T22:16:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.580</gpxtpx:speed>
+            <gpxtpx:course>78.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.790065" lon="-122.610221">
+        <time>2026-04-11T22:19:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.361</gpxtpx:speed>
+            <gpxtpx:course>101.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.791413" lon="-122.603622">
+        <time>2026-04-11T22:22:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.325</gpxtpx:speed>
+            <gpxtpx:course>82.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.792650" lon="-122.597105">
+        <time>2026-04-11T22:24:46Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.440</gpxtpx:speed>
+            <gpxtpx:course>75.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.793746" lon="-122.590752">
+        <time>2026-04-11T22:27:22Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.921</gpxtpx:speed>
+            <gpxtpx:course>69.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.794667" lon="-122.584179">
+        <time>2026-04-11T22:29:59Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.378</gpxtpx:speed>
+            <gpxtpx:course>79.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.795598" lon="-122.577595">
+        <time>2026-04-11T22:32:36Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.940</gpxtpx:speed>
+            <gpxtpx:course>71.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.796370" lon="-122.571047">
+        <time>2026-04-11T22:35:12Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.097</gpxtpx:speed>
+            <gpxtpx:course>85.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.797259" lon="-122.564208">
+        <time>2026-04-11T22:37:49Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.020</gpxtpx:speed>
+            <gpxtpx:course>83.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.798911" lon="-122.557410">
+        <time>2026-04-11T22:40:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.140</gpxtpx:speed>
+            <gpxtpx:course>78.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.800628" lon="-122.550525">
+        <time>2026-04-11T22:43:02Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.753</gpxtpx:speed>
+            <gpxtpx:course>57.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.801727" lon="-122.543741">
+        <time>2026-04-11T22:45:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.470</gpxtpx:speed>
+            <gpxtpx:course>84.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.803057" lon="-122.536738">
+        <time>2026-04-11T22:48:16Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.627</gpxtpx:speed>
+            <gpxtpx:course>75.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.804418" lon="-122.529527">
+        <time>2026-04-11T22:50:53Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.543</gpxtpx:speed>
+            <gpxtpx:course>75.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.805757" lon="-122.522296">
+        <time>2026-04-11T22:53:29Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.993</gpxtpx:speed>
+            <gpxtpx:course>72.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.807480" lon="-122.515180">
+        <time>2026-04-11T22:56:06Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.112</gpxtpx:speed>
+            <gpxtpx:course>89.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809568" lon="-122.508209">
+        <time>2026-04-11T22:58:43Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.430</gpxtpx:speed>
+            <gpxtpx:course>67.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.811594" lon="-122.501683">
+        <time>2026-04-11T23:01:19Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.539</gpxtpx:speed>
+            <gpxtpx:course>67.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.813116" lon="-122.495314">
+        <time>2026-04-11T23:03:56Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.287</gpxtpx:speed>
+            <gpxtpx:course>66.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814427" lon="-122.488791">
+        <time>2026-04-11T23:06:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.680</gpxtpx:speed>
+            <gpxtpx:course>79.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815377" lon="-122.481759">
+        <time>2026-04-11T23:09:09Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.150</gpxtpx:speed>
+            <gpxtpx:course>81.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815223" lon="-122.475638">
+        <time>2026-04-11T23:11:45Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.420</gpxtpx:speed>
+            <gpxtpx:course>102.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814014" lon="-122.469878">
+        <time>2026-04-11T23:14:21Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.722</gpxtpx:speed>
+            <gpxtpx:course>114.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.812331" lon="-122.464025">
+        <time>2026-04-11T23:16:57Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.145</gpxtpx:speed>
+            <gpxtpx:course>103.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.811197" lon="-122.456959">
+        <time>2026-04-11T23:19:33Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.987</gpxtpx:speed>
+            <gpxtpx:course>78.3</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.809968" lon="-122.449874">
+        <time>2026-04-11T23:22:10Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.534</gpxtpx:speed>
+            <gpxtpx:course>97.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.810842" lon="-122.442129">
+        <time>2026-04-11T23:24:46Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.790</gpxtpx:speed>
+            <gpxtpx:course>78.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.813020" lon="-122.434256">
+        <time>2026-04-11T23:27:23Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.056</gpxtpx:speed>
+            <gpxtpx:course>65.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.814980" lon="-122.425931">
+        <time>2026-04-11T23:30:00Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>5.315</gpxtpx:speed>
+            <gpxtpx:course>79.4</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.816208" lon="-122.417401">
+        <time>2026-04-11T23:32:37Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.930</gpxtpx:speed>
+            <gpxtpx:course>89.7</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.815015" lon="-122.409167">
+        <time>2026-04-11T23:35:13Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.690</gpxtpx:speed>
+            <gpxtpx:course>104.2</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.811850" lon="-122.402340">
+        <time>2026-04-11T23:37:50Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.243</gpxtpx:speed>
+            <gpxtpx:course>126.6</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.807890" lon="-122.397358">
+        <time>2026-04-11T23:40:26Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>4.098</gpxtpx:speed>
+            <gpxtpx:course>167.0</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.803465" lon="-122.393577">
+        <time>2026-04-11T23:43:03Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.770</gpxtpx:speed>
+            <gpxtpx:course>143.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.799421" lon="-122.389408">
+        <time>2026-04-11T23:45:39Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.700</gpxtpx:speed>
+            <gpxtpx:course>140.8</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.795440" lon="-122.385504">
+        <time>2026-04-11T23:48:15Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.740</gpxtpx:speed>
+            <gpxtpx:course>157.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.790795" lon="-122.383824">
+        <time>2026-04-11T23:50:51Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.179</gpxtpx:speed>
+            <gpxtpx:course>149.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.786829" lon="-122.382874">
+        <time>2026-04-11T23:53:28Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>2.754</gpxtpx:speed>
+            <gpxtpx:course>183.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.782688" lon="-122.384467">
+        <time>2026-04-11T23:56:05Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>3.451</gpxtpx:speed>
+            <gpxtpx:course>208.1</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks/2026-04-20.gpx
+++ b/data/telemetry/tracks/2026-04-20.gpx
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" version="1.1" creator="S.V.Mermug">
+  <metadata>
+    <name>S.V.Mermug — 2026-04-20</name>
+    <time>2026-04-20T00:46:25Z</time>
+  </metadata>
+  <trk>
+    <name>S.V.Mermug — 2026-04-20</name>
+    <trkseg>
+      <trkpt lat="37.789682" lon="-122.374302">
+        <time>2026-04-20T00:46:25Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>1.525</gpxtpx:speed>
+            <gpxtpx:course>268.5</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+      <trkpt lat="37.790123" lon="-122.375936">
+        <time>2026-04-20T00:49:01Z</time>
+        <extensions>
+          <gpxtpx:TrackPointExtension>
+            <gpxtpx:speed>0.479</gpxtpx:speed>
+            <gpxtpx:course>284.9</gpxtpx:course>
+          </gpxtpx:TrackPointExtension>
+        </extensions>
+      </trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/data/telemetry/tracks_index.json
+++ b/data/telemetry/tracks_index.json
@@ -1,0 +1,164 @@
+{
+  "tracks": [
+    {
+      "date": "2026-02-28",
+      "file": "tracks/2026-02-28.gpx",
+      "start": "2026-02-28T23:02:37Z",
+      "end": "2026-02-28T23:59:26Z",
+      "duration_hours": 0.95,
+      "points": 23,
+      "max_speed_kts": 9.5,
+      "distance_nm": 5.15
+    },
+    {
+      "date": "2026-03-01",
+      "file": "tracks/2026-03-01.gpx",
+      "start": "2026-03-01T00:02:00Z",
+      "end": "2026-03-01T02:37:04Z",
+      "duration_hours": 2.58,
+      "points": 60,
+      "max_speed_kts": 9.9,
+      "distance_nm": 7.61
+    },
+    {
+      "date": "2026-03-05",
+      "file": "tracks/2026-03-05.gpx",
+      "start": "2026-03-05T01:19:24Z",
+      "end": "2026-03-05T02:51:39Z",
+      "duration_hours": 1.54,
+      "points": 37,
+      "max_speed_kts": 9.3,
+      "distance_nm": 6.16
+    },
+    {
+      "date": "2026-03-08",
+      "file": "tracks/2026-03-08.gpx",
+      "start": "2026-03-08T19:44:59Z",
+      "end": "2026-03-08T23:21:08Z",
+      "duration_hours": 3.6,
+      "points": 85,
+      "max_speed_kts": 7.9,
+      "distance_nm": 17.02
+    },
+    {
+      "date": "2026-03-09",
+      "file": "tracks/2026-03-09.gpx",
+      "start": "2026-03-09T14:12:32Z",
+      "end": "2026-03-09T15:37:47Z",
+      "duration_hours": 1.42,
+      "points": 34,
+      "max_speed_kts": 9.8,
+      "distance_nm": 10.28
+    },
+    {
+      "date": "2026-03-11",
+      "file": "tracks/2026-03-11.gpx",
+      "start": "2026-03-11T22:38:06Z",
+      "end": "2026-03-11T23:58:19Z",
+      "duration_hours": 1.34,
+      "points": 32,
+      "max_speed_kts": 9.0,
+      "distance_nm": 9.22
+    },
+    {
+      "date": "2026-03-12",
+      "file": "tracks/2026-03-12.gpx",
+      "start": "2026-03-12T00:00:58Z",
+      "end": "2026-03-12T01:08:00Z",
+      "duration_hours": 1.12,
+      "points": 22,
+      "max_speed_kts": 8.8,
+      "distance_nm": 5.02
+    },
+    {
+      "date": "2026-03-14",
+      "file": "tracks/2026-03-14.gpx",
+      "start": "2026-03-14T18:57:39Z",
+      "end": "2026-03-14T23:57:42Z",
+      "duration_hours": 5.0,
+      "points": 117,
+      "max_speed_kts": 9.8,
+      "distance_nm": 21.16
+    },
+    {
+      "date": "2026-03-15",
+      "file": "tracks/2026-03-15.gpx",
+      "start": "2026-03-15T19:11:04Z",
+      "end": "2026-03-15T22:30:18Z",
+      "duration_hours": 3.32,
+      "points": 78,
+      "max_speed_kts": 8.1,
+      "distance_nm": 10.71
+    },
+    {
+      "date": "2026-03-21",
+      "file": "tracks/2026-03-21.gpx",
+      "start": "2026-03-21T00:21:16Z",
+      "end": "2026-03-21T18:21:43Z",
+      "duration_hours": 18.01,
+      "points": 403,
+      "max_speed_kts": 10.5,
+      "distance_nm": 9.68
+    },
+    {
+      "date": "2026-03-26",
+      "file": "tracks/2026-03-26.gpx",
+      "start": "2026-03-26T23:36:53Z",
+      "end": "2026-03-26T23:57:39Z",
+      "duration_hours": 0.35,
+      "points": 9,
+      "max_speed_kts": 5.7,
+      "distance_nm": 1.4
+    },
+    {
+      "date": "2026-03-27",
+      "file": "tracks/2026-03-27.gpx",
+      "start": "2026-03-27T00:00:15Z",
+      "end": "2026-03-27T01:44:17Z",
+      "duration_hours": 1.73,
+      "points": 41,
+      "max_speed_kts": 9.2,
+      "distance_nm": 9.74
+    },
+    {
+      "date": "2026-04-04",
+      "file": "tracks/2026-04-04.gpx",
+      "start": "2026-04-04T20:28:17Z",
+      "end": "2026-04-04T23:59:02Z",
+      "duration_hours": 3.51,
+      "points": 82,
+      "max_speed_kts": 8.0,
+      "distance_nm": 15.84
+    },
+    {
+      "date": "2026-04-05",
+      "file": "tracks/2026-04-05.gpx",
+      "start": "2026-04-05T00:01:39Z",
+      "end": "2026-04-05T00:43:16Z",
+      "duration_hours": 0.69,
+      "points": 17,
+      "max_speed_kts": 6.3,
+      "distance_nm": 2.24
+    },
+    {
+      "date": "2026-04-11",
+      "file": "tracks/2026-04-11.gpx",
+      "start": "2026-04-11T14:37:09Z",
+      "end": "2026-04-11T23:56:05Z",
+      "duration_hours": 9.32,
+      "points": 181,
+      "max_speed_kts": 10.5,
+      "distance_nm": 63.62
+    },
+    {
+      "date": "2026-04-20",
+      "file": "tracks/2026-04-20.gpx",
+      "start": "2026-04-20T00:46:25Z",
+      "end": "2026-04-20T00:49:01Z",
+      "duration_hours": 0.04,
+      "points": 2,
+      "max_speed_kts": 3.0,
+      "distance_nm": 0.08
+    }
+  ]
+}

--- a/scripts/backfill_tracks.py
+++ b/scripts/backfill_tracks.py
@@ -1,0 +1,228 @@
+"""Backfill per-day GPX track files from all telemetry position snapshots.
+
+Reads every timestamped JSON snapshot in data/telemetry/, filters out positions
+inside the South Beach Harbor privacy zone, and produces:
+
+  data/telemetry/tracks/YYYY-MM-DD.gpx   — one GPX per sailing day (UTC date)
+  data/telemetry/tracks_index.json        — index of all sailing days with metadata
+
+Existing GPX files are never overwritten so the script is safe to re-run;
+it only fills in missing days and appends new metadata entries.
+
+Run from the repo root:
+    uv run python -m scripts.backfill_tracks
+"""
+from __future__ import annotations
+
+import json
+import math
+import xml.etree.ElementTree as ET
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from .utils import get_project_root, load_vessel_info
+
+TELEMETRY_DIR = Path("data/telemetry")
+TRACKS_DIR = TELEMETRY_DIR / "tracks"
+TRACKS_INDEX_FILE = TELEMETRY_DIR / "tracks_index.json"
+
+HARBOR_LAT = 37.7802069
+HARBOR_LON = -122.3858040
+HARBOR_RADIUS_M = 200.0
+
+_NS_GPX = "http://www.topografix.com/GPX/1/1"
+_NS_GPXTPX = "http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
+ET.register_namespace("", _NS_GPX)
+ET.register_namespace("gpxtpx", _NS_GPXTPX)
+
+
+def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    R = 6_371_000.0
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlam = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlam / 2) ** 2
+    return R * 2 * math.asin(math.sqrt(a))
+
+
+def _fmt_gpx_time(ts: str) -> str:
+    try:
+        dt = datetime.fromisoformat(ts)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        else:
+            dt = dt.astimezone(UTC)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return ts
+
+
+def _parse_snapshot(path: Path) -> dict[str, Any] | None:
+    """Extract (timestamp, lat, lon, speed_ms, course_rad) from a SignalK snapshot file."""
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    updates = data.get("updates", [])
+    if not updates:
+        return None
+    update = updates[0]
+    ts = update.get("timestamp")
+    if not ts:
+        return None
+
+    lat = lon = speed = course = None
+    for v in update.get("values", []):
+        p = v.get("path", "")
+        val = v.get("value")
+        if p == "navigation.position" and isinstance(val, dict):
+            lat = val.get("latitude")
+            lon = val.get("longitude")
+        elif p == "navigation.speedOverGround" and isinstance(val, (int, float)):
+            speed = float(val)
+        elif p == "navigation.courseOverGroundTrue" and isinstance(val, (int, float)):
+            course = float(val)
+
+    if not isinstance(lat, (int, float)) or not isinstance(lon, (int, float)):
+        return None
+
+    return {"timestamp": ts, "latitude": float(lat), "longitude": float(lon),
+            "speed_ms": speed, "course_rad": course}
+
+
+def _build_day_gpx(points: list[dict[str, Any]], date_str: str, vessel_name: str) -> str:
+    g = ET.Element(f"{{{_NS_GPX}}}gpx", {"version": "1.1", "creator": vessel_name})
+    meta = ET.SubElement(g, f"{{{_NS_GPX}}}metadata")
+    ET.SubElement(meta, f"{{{_NS_GPX}}}name").text = f"{vessel_name} \u2014 {date_str}"
+    ET.SubElement(meta, f"{{{_NS_GPX}}}time").text = _fmt_gpx_time(points[0]["timestamp"])
+    trk = ET.SubElement(g, f"{{{_NS_GPX}}}trk")
+    ET.SubElement(trk, f"{{{_NS_GPX}}}name").text = f"{vessel_name} \u2014 {date_str}"
+    seg = ET.SubElement(trk, f"{{{_NS_GPX}}}trkseg")
+    for p in points:
+        trkpt = ET.SubElement(seg, f"{{{_NS_GPX}}}trkpt", {
+            "lat": f"{p['latitude']:.6f}",
+            "lon": f"{p['longitude']:.6f}",
+        })
+        ET.SubElement(trkpt, f"{{{_NS_GPX}}}time").text = _fmt_gpx_time(p["timestamp"])
+        speed, course = p.get("speed_ms"), p.get("course_rad")
+        if speed is not None or course is not None:
+            ext = ET.SubElement(trkpt, f"{{{_NS_GPX}}}extensions")
+            tpe = ET.SubElement(ext, f"{{{_NS_GPXTPX}}}TrackPointExtension")
+            if speed is not None:
+                ET.SubElement(tpe, f"{{{_NS_GPXTPX}}}speed").text = f"{speed:.3f}"
+            if course is not None:
+                ET.SubElement(tpe, f"{{{_NS_GPXTPX}}}course").text = f"{math.degrees(course) % 360:.1f}"
+    ET.indent(g, space="  ")
+    return ET.tostring(g, encoding="unicode")
+
+
+def _make_track_meta(date_str: str, points: list[dict[str, Any]]) -> dict[str, Any]:
+    total_nm = 0.0
+    max_spd_kts = 0.0
+    for i, p in enumerate(points):
+        spd = p.get("speed_ms")
+        if spd is not None:
+            max_spd_kts = max(max_spd_kts, spd * 1.94384)
+        if i > 0:
+            prev = points[i - 1]
+            total_nm += _haversine_m(
+                prev["latitude"], prev["longitude"], p["latitude"], p["longitude"]
+            ) / 1852.0
+    start_ts, end_ts = points[0]["timestamp"], points[-1]["timestamp"]
+    try:
+        start_dt = datetime.fromisoformat(start_ts).astimezone(UTC)
+        end_dt = datetime.fromisoformat(end_ts).astimezone(UTC)
+        duration_h = (end_dt - start_dt).total_seconds() / 3600
+    except ValueError:
+        duration_h = 0.0
+    return {
+        "date": date_str,
+        "file": f"tracks/{date_str}.gpx",
+        "start": _fmt_gpx_time(start_ts),
+        "end": _fmt_gpx_time(end_ts),
+        "duration_hours": round(duration_h, 2),
+        "points": len(points),
+        "max_speed_kts": round(max_spd_kts, 1),
+        "distance_nm": round(total_nm, 2),
+    }
+
+
+def _load_tracks_index(path: Path) -> dict[str, dict[str, Any]]:
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+        tracks = data.get("tracks", data) if isinstance(data, dict) else data
+        return {t["date"]: t for t in tracks if isinstance(t, dict) and "date" in t}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def main() -> int:
+    root = get_project_root()
+    telemetry_dir = root / TELEMETRY_DIR
+    tracks_dir = root / TRACKS_DIR
+    tracks_index_path = root / TRACKS_INDEX_FILE
+
+    try:
+        vessel_info = load_vessel_info("data/vessel/info.yaml")
+        vessel_name = vessel_info.get("name", "Vessel")
+    except Exception:
+        vessel_name = "Vessel"
+
+    # Collect all timestamped snapshot files (skip index/latest files)
+    skip = {"signalk_latest.json", "positions_index.json", "snapshots_index.json",
+            "tracks_index.json"}
+    files = sorted(
+        f for f in telemetry_dir.glob("*.json")
+        if f.name not in skip and not f.name.startswith("tracks")
+    )
+    print(f"Found {len(files)} snapshot files")
+
+    # Parse and group by UTC date
+    by_day: dict[str, list[dict[str, Any]]] = {}
+    skipped = 0
+    for path in files:
+        pt = _parse_snapshot(path)
+        if pt is None:
+            skipped += 1
+            continue
+        if _haversine_m(pt["latitude"], pt["longitude"], HARBOR_LAT, HARBOR_LON) <= HARBOR_RADIUS_M:
+            continue
+        date_str = pt["timestamp"][:10]
+        by_day.setdefault(date_str, []).append(pt)
+
+    print(f"Parsed {len(files) - skipped} points across {len(by_day)} sailing days "
+          f"({skipped} files skipped)")
+
+    # Load existing index so we don't duplicate entries
+    existing = _load_tracks_index(tracks_index_path)
+    tracks_dir.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    for date_str, points in sorted(by_day.items()):
+        gpx_path = tracks_dir / f"{date_str}.gpx"
+        if gpx_path.exists():
+            existing.setdefault(date_str, _make_track_meta(date_str, points))
+            continue
+        gpx_xml = _build_day_gpx(points, date_str, vessel_name)
+        gpx_path.write_text(f'<?xml version="1.0" encoding="UTF-8"?>\n{gpx_xml}\n',
+                             encoding="utf-8")
+        existing[date_str] = _make_track_meta(date_str, points)
+        print(f"  Wrote {gpx_path.name}  ({len(points)} pts)")
+        written += 1
+
+    tracks_index_path.write_text(
+        json.dumps({"tracks": sorted(existing.values(), key=lambda t: t["date"])}, indent=2),
+        encoding="utf-8",
+    )
+    print(f"Done. {written} GPX files written, {len(existing)} total sailing days indexed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_signalk_data.py
+++ b/scripts/update_signalk_data.py
@@ -4,6 +4,7 @@ import math
 import os
 import subprocess
 import time
+import xml.etree.ElementTree as ET
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -18,6 +19,13 @@ STALE_MAX_AGE_MINUTES = 60
 STALE_FILTER_KEYS = ("environment", "navigation", "entertainment")
 POSITION_RETENTION_HOURS = (24 * 24)  # 24 days
 POSITION_INDEX_FILE = "./data/telemetry/positions_index.json"
+TRACKS_DIR = "./data/telemetry/tracks"
+TRACKS_INDEX_FILE = "./data/telemetry/tracks_index.json"
+
+_NS_GPX = "http://www.topografix.com/GPX/1/1"
+_NS_GPXTPX = "http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
+ET.register_namespace("", _NS_GPX)
+ET.register_namespace("gpxtpx", _NS_GPXTPX)
 # All snapshot files (timestamp + filename only, no position — safe to publish).
 # Used by the frontend sparkline feature to load historical telemetry for all paths.
 SNAPSHOT_INDEX_FILE = "./data/telemetry/snapshots_index.json"
@@ -376,6 +384,162 @@ def _prune_old_position_files(output_dir: Path) -> None:
             file_path.unlink(missing_ok=True)
 
 
+# ── Per-day GPX track files ────────────────────────────────────────────────
+
+def _load_tracks_index(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text())
+        tracks = data.get("tracks", data) if isinstance(data, dict) else data
+        return tracks if isinstance(tracks, list) else []
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def _write_tracks_index(path: Path, entries: list[dict[str, Any]]) -> None:
+    path.write_text(json.dumps({"tracks": entries}, indent=2), encoding="utf-8")
+
+
+def _fmt_gpx_time(ts: str) -> str:
+    try:
+        dt = datetime.fromisoformat(ts)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        else:
+            dt = dt.astimezone(UTC)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return ts
+
+
+def _extract_pos_from_values(
+    values: list[dict[str, Any]],
+) -> tuple[float | None, float | None, float | None, float | None]:
+    """Return (lat, lon, speed_ms, course_rad) from a positions index values list."""
+    lat = lon = speed = course = None
+    for v in values:
+        p = v.get("path", "")
+        val = v.get("value")
+        if p == "navigation.position" and isinstance(val, dict):
+            lat = val.get("latitude")
+            lon = val.get("longitude")
+        elif p == "navigation.speedOverGround" and isinstance(val, (int, float)):
+            speed = float(val)
+        elif p == "navigation.courseOverGroundTrue" and isinstance(val, (int, float)):
+            course = float(val)
+    return lat, lon, speed, course
+
+
+def _build_day_gpx(points: list[dict[str, Any]], date_str: str, vessel_name: str) -> str:
+    """Serialise one sailing day's points to a GPX XML string (no XML declaration)."""
+    g = ET.Element(f"{{{_NS_GPX}}}gpx", {"version": "1.1", "creator": vessel_name})
+    meta = ET.SubElement(g, f"{{{_NS_GPX}}}metadata")
+    ET.SubElement(meta, f"{{{_NS_GPX}}}name").text = f"{vessel_name} \u2014 {date_str}"
+    ET.SubElement(meta, f"{{{_NS_GPX}}}time").text = _fmt_gpx_time(points[0]["timestamp"])
+    trk = ET.SubElement(g, f"{{{_NS_GPX}}}trk")
+    ET.SubElement(trk, f"{{{_NS_GPX}}}name").text = f"{vessel_name} \u2014 {date_str}"
+    seg = ET.SubElement(trk, f"{{{_NS_GPX}}}trkseg")
+    for p in points:
+        trkpt = ET.SubElement(seg, f"{{{_NS_GPX}}}trkpt", {
+            "lat": f"{p['latitude']:.6f}",
+            "lon": f"{p['longitude']:.6f}",
+        })
+        ET.SubElement(trkpt, f"{{{_NS_GPX}}}time").text = _fmt_gpx_time(p["timestamp"])
+        speed = p.get("speed_ms")
+        course = p.get("course_rad")
+        if speed is not None or course is not None:
+            ext = ET.SubElement(trkpt, f"{{{_NS_GPX}}}extensions")
+            tpe = ET.SubElement(ext, f"{{{_NS_GPXTPX}}}TrackPointExtension")
+            if speed is not None:
+                ET.SubElement(tpe, f"{{{_NS_GPXTPX}}}speed").text = f"{speed:.3f}"
+            if course is not None:
+                ET.SubElement(tpe, f"{{{_NS_GPXTPX}}}course").text = f"{math.degrees(course) % 360:.1f}"
+    ET.indent(g, space="  ")
+    return ET.tostring(g, encoding="unicode")
+
+
+def _make_track_meta(date_str: str, points: list[dict[str, Any]]) -> dict[str, Any]:
+    total_nm = 0.0
+    max_spd_kts = 0.0
+    for i, p in enumerate(points):
+        spd = p.get("speed_ms")
+        if spd is not None:
+            max_spd_kts = max(max_spd_kts, spd * 1.94384)
+        if i > 0:
+            prev = points[i - 1]
+            total_nm += _haversine_m(
+                prev["latitude"], prev["longitude"], p["latitude"], p["longitude"]
+            ) / 1852.0
+    start_ts, end_ts = points[0]["timestamp"], points[-1]["timestamp"]
+    try:
+        start_dt = datetime.fromisoformat(start_ts).astimezone(UTC)
+        end_dt = datetime.fromisoformat(end_ts).astimezone(UTC)
+        duration_h = (end_dt - start_dt).total_seconds() / 3600
+    except ValueError:
+        duration_h = 0.0
+    return {
+        "date": date_str,
+        "file": f"tracks/{date_str}.gpx",
+        "start": _fmt_gpx_time(start_ts),
+        "end": _fmt_gpx_time(end_ts),
+        "duration_hours": round(duration_h, 2),
+        "points": len(points),
+        "max_speed_kts": round(max_spd_kts, 1),
+        "distance_nm": round(total_nm, 2),
+    }
+
+
+def _update_track_files(
+    all_entries: list[dict[str, Any]],
+    tracks_dir: Path,
+    tracks_index_path: Path,
+    vessel_name: str,
+) -> None:
+    """Generate/update per-day GPX files from positions index entries.
+
+    Past days are written once and never overwritten. Today's file is always
+    refreshed so it accumulates points throughout the sailing day. Existing
+    GPX files from earlier backfills are never deleted.
+    """
+    today_utc = datetime.now(UTC).strftime("%Y-%m-%d")
+    harbor_lat, harbor_lon, harbor_radius = PRIVACY_EXCLUSION_ZONES[0]
+
+    by_day: dict[str, list[dict[str, Any]]] = {}
+    for entry in all_entries:
+        ts = entry.get("timestamp", "")
+        lat, lon, speed, course = _extract_pos_from_values(entry.get("values", []))
+        if lat is None or lon is None or not ts:
+            continue
+        if _haversine_m(lat, lon, harbor_lat, harbor_lon) <= harbor_radius:
+            continue
+        date_str = ts[:10]
+        by_day.setdefault(date_str, []).append({
+            "timestamp": ts,
+            "latitude": lat,
+            "longitude": lon,
+            "speed_ms": speed,
+            "course_rad": course,
+        })
+
+    if not by_day:
+        return
+
+    tracks_dir.mkdir(parents=True, exist_ok=True)
+    existing = {t["date"]: t for t in _load_tracks_index(tracks_index_path)}
+
+    for date_str, points in by_day.items():
+        gpx_path = tracks_dir / f"{date_str}.gpx"
+        if gpx_path.exists() and date_str != today_utc:
+            existing.setdefault(date_str, _make_track_meta(date_str, points))
+            continue
+        gpx_xml = _build_day_gpx(points, date_str, vessel_name)
+        gpx_path.write_text(f'<?xml version="1.0" encoding="UTF-8"?>\n{gpx_xml}\n', encoding="utf-8")
+        existing[date_str] = _make_track_meta(date_str, points)
+
+    _write_tracks_index(tracks_index_path, sorted(existing.values(), key=lambda t: t["date"]))
+
+
 def update_position_cache(blob: dict[str, Any], output_path: Path) -> None:
     navigation = blob.get("navigation", {}) if isinstance(blob, dict) else {}
     position = navigation.get("position") if isinstance(navigation, dict) else None
@@ -464,6 +628,17 @@ def update_position_cache(blob: dict[str, Any], output_path: Path) -> None:
     entries.append(index_entry)
     entries.sort(key=lambda item: item.get("timestamp") or "")
     _write_position_index(index_path, entries)
+
+    try:
+        vessel_name = load_vessel_data().get("vessel_data", {}).get("name", "Vessel")
+    except Exception:
+        vessel_name = "Vessel"
+    _update_track_files(
+        entries,
+        output_dir / "tracks",
+        output_dir / Path(TRACKS_INDEX_FILE).name,
+        vessel_name,
+    )
 
     _prune_old_position_files(output_dir)
 

--- a/tests/test_gpx_tracks.py
+++ b/tests/test_gpx_tracks.py
@@ -1,0 +1,489 @@
+"""Tests for per-day GPX track generation and backfill script."""
+from __future__ import annotations
+
+import json
+import math
+import xml.etree.ElementTree as ET
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import scripts.update_signalk_data as usd
+import scripts.backfill_tracks as bt
+
+# ---------------------------------------------------------------------------
+# Helpers / shared fixtures
+# ---------------------------------------------------------------------------
+
+HARBOR_LAT = 37.7802069
+HARBOR_LON = -122.3858040
+
+# A position clearly outside the harbor (~6 km NW, near the Golden Gate)
+OUTSIDE_LAT = 37.8229
+OUTSIDE_LON = -122.4373
+
+# A position inside the harbor exclusion zone
+INSIDE_LAT = HARBOR_LAT
+INSIDE_LON = HARBOR_LON
+
+NS = {"gpx": "http://www.topografix.com/GPX/1/1",
+      "gpxtpx": "http://www.garmin.com/xmlschemas/TrackPointExtension/v1"}
+
+
+def _make_index_entry(
+    ts: str,
+    lat: float = OUTSIDE_LAT,
+    lon: float = OUTSIDE_LON,
+    speed: float | None = 2.5,
+    course: float | None = 1.57,
+) -> dict:
+    values = [{"path": "navigation.position", "value": {"latitude": lat, "longitude": lon}}]
+    if speed is not None:
+        values.append({"path": "navigation.speedOverGround", "value": speed})
+    if course is not None:
+        values.append({"path": "navigation.courseOverGroundTrue", "value": course})
+    return {"timestamp": ts, "file": f"{ts[:10]}T00-00-00.000000Z.json", "values": values}
+
+
+def _make_snapshot_file(tmp_path: Path, ts: str, lat: float, lon: float,
+                         speed: float | None = None, course: float | None = None) -> Path:
+    """Write a fake SignalK snapshot file in the expected format."""
+    values = [{"path": "navigation.position", "value": {"latitude": lat, "longitude": lon}}]
+    if speed is not None:
+        values.append({"path": "navigation.speedOverGround", "value": speed})
+    if course is not None:
+        values.append({"path": "navigation.courseOverGroundTrue", "value": course})
+    payload = {"context": "vessels.self", "updates": [{"timestamp": ts, "values": values}]}
+    # Filename must match the timestamp pattern
+    fname = ts.replace(":", "-").replace("+00:00", "Z").replace(".", ".") + ".json"
+    # Simplify: use a known-good filename format
+    fname = f"{ts[:10]}T{ts[11:19].replace(':', '-')}.000000Z.json"
+    path = tmp_path / fname
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# _fmt_gpx_time
+# ---------------------------------------------------------------------------
+
+def test_fmt_gpx_time_utc_offset():
+    result = usd._fmt_gpx_time("2026-04-11T15:00:15+00:00")
+    assert result == "2026-04-11T15:00:15Z"
+
+
+def test_fmt_gpx_time_strips_microseconds():
+    result = usd._fmt_gpx_time("2026-04-11T15:00:15.864000+00:00")
+    assert result == "2026-04-11T15:00:15Z"
+
+
+def test_fmt_gpx_time_no_tz_treated_as_utc():
+    result = usd._fmt_gpx_time("2026-04-11T15:00:15")
+    assert result == "2026-04-11T15:00:15Z"
+
+
+def test_fmt_gpx_time_passthrough_on_bad_value():
+    bad = "not-a-timestamp"
+    assert usd._fmt_gpx_time(bad) == bad
+
+
+# ---------------------------------------------------------------------------
+# _extract_pos_from_values
+# ---------------------------------------------------------------------------
+
+def test_extract_pos_full():
+    values = [
+        {"path": "navigation.position", "value": {"latitude": 37.82, "longitude": -122.44}},
+        {"path": "navigation.speedOverGround", "value": 2.5},
+        {"path": "navigation.courseOverGroundTrue", "value": 1.57},
+    ]
+    lat, lon, speed, course = usd._extract_pos_from_values(values)
+    assert lat == pytest.approx(37.82)
+    assert lon == pytest.approx(-122.44)
+    assert speed == pytest.approx(2.5)
+    assert course == pytest.approx(1.57)
+
+
+def test_extract_pos_missing_speed_course():
+    values = [
+        {"path": "navigation.position", "value": {"latitude": 37.82, "longitude": -122.44}},
+    ]
+    lat, lon, speed, course = usd._extract_pos_from_values(values)
+    assert lat == pytest.approx(37.82)
+    assert lon == pytest.approx(-122.44)
+    assert speed is None
+    assert course is None
+
+
+def test_extract_pos_no_position():
+    values = [{"path": "navigation.speedOverGround", "value": 3.0}]
+    lat, lon, speed, course = usd._extract_pos_from_values(values)
+    assert lat is None
+    assert lon is None
+    assert speed == pytest.approx(3.0)
+
+
+def test_extract_pos_empty():
+    lat, lon, speed, course = usd._extract_pos_from_values([])
+    assert all(v is None for v in (lat, lon, speed, course))
+
+
+# ---------------------------------------------------------------------------
+# _build_day_gpx
+# ---------------------------------------------------------------------------
+
+def _sample_points(n: int = 3) -> list[dict]:
+    return [
+        {
+            "timestamp": f"2026-04-11T1{i}:00:00+00:00",
+            "latitude": 37.82 + i * 0.01,
+            "longitude": -122.44 + i * 0.01,
+            "speed_ms": 2.5 + i * 0.1,
+            "course_rad": 1.57 + i * 0.05,
+        }
+        for i in range(n)
+    ]
+
+
+def test_build_day_gpx_is_valid_xml():
+    xml_str = usd._build_day_gpx(_sample_points(), "2026-04-11", "S.V. Test")
+    root = ET.fromstring(xml_str)
+    assert root is not None
+
+
+def test_build_day_gpx_correct_point_count():
+    pts = _sample_points(5)
+    xml_str = usd._build_day_gpx(pts, "2026-04-11", "S.V. Test")
+    root = ET.fromstring(xml_str)
+    trkpts = root.findall(".//gpx:trkpt", NS)
+    assert len(trkpts) == 5
+
+
+def test_build_day_gpx_lat_lon_correct():
+    pts = [{"timestamp": "2026-04-11T15:00:00+00:00",
+            "latitude": 37.822875, "longitude": -122.437270,
+            "speed_ms": 2.5, "course_rad": 1.57}]
+    xml_str = usd._build_day_gpx(pts, "2026-04-11", "S.V. Test")
+    root = ET.fromstring(xml_str)
+    trkpt = root.find(".//gpx:trkpt", NS)
+    assert float(trkpt.attrib["lat"]) == pytest.approx(37.822875, abs=1e-5)
+    assert float(trkpt.attrib["lon"]) == pytest.approx(-122.437270, abs=1e-5)
+
+
+def test_build_day_gpx_speed_extension():
+    pts = [{"timestamp": "2026-04-11T15:00:00+00:00",
+            "latitude": 37.82, "longitude": -122.44,
+            "speed_ms": 4.0, "course_rad": 0.0}]
+    xml_str = usd._build_day_gpx(pts, "2026-04-11", "S.V. Test")
+    root = ET.fromstring(xml_str)
+    speed_el = root.find(".//gpxtpx:speed", NS)
+    assert speed_el is not None
+    assert float(speed_el.text) == pytest.approx(4.0, abs=0.01)
+
+
+def test_build_day_gpx_course_extension_in_degrees():
+    pts = [{"timestamp": "2026-04-11T15:00:00+00:00",
+            "latitude": 37.82, "longitude": -122.44,
+            "speed_ms": 2.0, "course_rad": math.pi}]  # π rad = 180°
+    xml_str = usd._build_day_gpx(pts, "2026-04-11", "S.V. Test")
+    root = ET.fromstring(xml_str)
+    course_el = root.find(".//gpxtpx:course", NS)
+    assert course_el is not None
+    assert float(course_el.text) == pytest.approx(180.0, abs=0.2)
+
+
+def test_build_day_gpx_no_extension_when_no_speed_course():
+    pts = [{"timestamp": "2026-04-11T15:00:00+00:00",
+            "latitude": 37.82, "longitude": -122.44,
+            "speed_ms": None, "course_rad": None}]
+    xml_str = usd._build_day_gpx(pts, "2026-04-11", "S.V. Test")
+    root = ET.fromstring(xml_str)
+    assert root.find(".//gpx:extensions", NS) is None
+
+
+def test_build_day_gpx_track_name_contains_date():
+    xml_str = usd._build_day_gpx(_sample_points(), "2026-04-11", "S.V. Mermug")
+    root = ET.fromstring(xml_str)
+    name_el = root.find(".//gpx:trk/gpx:name", NS)
+    assert name_el is not None
+    assert "2026-04-11" in name_el.text
+    assert "Mermug" in name_el.text
+
+
+# ---------------------------------------------------------------------------
+# _make_track_meta
+# ---------------------------------------------------------------------------
+
+def test_make_track_meta_basic_fields():
+    pts = [
+        {"timestamp": "2026-04-11T15:00:00+00:00", "latitude": 37.82, "longitude": -122.44,
+         "speed_ms": 3.0, "course_rad": 1.0},
+        {"timestamp": "2026-04-11T16:00:00+00:00", "latitude": 37.83, "longitude": -122.43,
+         "speed_ms": 5.0, "course_rad": 1.1},
+    ]
+    meta = usd._make_track_meta("2026-04-11", pts)
+    assert meta["date"] == "2026-04-11"
+    assert meta["file"] == "tracks/2026-04-11.gpx"
+    assert meta["points"] == 2
+    assert meta["start"] == "2026-04-11T15:00:00Z"
+    assert meta["end"] == "2026-04-11T16:00:00Z"
+
+
+def test_make_track_meta_duration():
+    pts = [
+        {"timestamp": "2026-04-11T12:00:00+00:00", "latitude": 37.82, "longitude": -122.44,
+         "speed_ms": 3.0, "course_rad": 0.0},
+        {"timestamp": "2026-04-11T14:30:00+00:00", "latitude": 37.83, "longitude": -122.43,
+         "speed_ms": 4.0, "course_rad": 0.0},
+    ]
+    meta = usd._make_track_meta("2026-04-11", pts)
+    assert meta["duration_hours"] == pytest.approx(2.5, abs=0.01)
+
+
+def test_make_track_meta_max_speed_kts():
+    pts = [
+        {"timestamp": "2026-04-11T12:00:00+00:00", "latitude": 37.82, "longitude": -122.44,
+         "speed_ms": 5.144, "course_rad": 0.0},   # ≈ 10 kts
+        {"timestamp": "2026-04-11T12:05:00+00:00", "latitude": 37.83, "longitude": -122.43,
+         "speed_ms": 2.572, "course_rad": 0.0},   # ≈ 5 kts
+    ]
+    meta = usd._make_track_meta("2026-04-11", pts)
+    assert meta["max_speed_kts"] == pytest.approx(10.0, abs=0.1)
+
+
+def test_make_track_meta_distance_positive():
+    pts = [
+        {"timestamp": "2026-04-11T12:00:00+00:00", "latitude": 37.80, "longitude": -122.44,
+         "speed_ms": 3.0, "course_rad": 0.0},
+        {"timestamp": "2026-04-11T12:10:00+00:00", "latitude": 37.85, "longitude": -122.44,
+         "speed_ms": 3.0, "course_rad": 0.0},
+    ]
+    meta = usd._make_track_meta("2026-04-11", pts)
+    assert meta["distance_nm"] > 0
+
+
+# ---------------------------------------------------------------------------
+# _load_tracks_index / _write_tracks_index round-trip
+# ---------------------------------------------------------------------------
+
+def test_tracks_index_round_trip(tmp_path):
+    entries = [
+        {"date": "2026-04-11", "file": "tracks/2026-04-11.gpx", "points": 181},
+        {"date": "2026-03-21", "file": "tracks/2026-03-21.gpx", "points": 403},
+    ]
+    path = tmp_path / "tracks_index.json"
+    usd._write_tracks_index(path, entries)
+    loaded = usd._load_tracks_index(path)
+    assert len(loaded) == 2
+    assert loaded[0]["date"] == "2026-04-11"
+
+
+def test_load_tracks_index_missing_file(tmp_path):
+    result = usd._load_tracks_index(tmp_path / "nonexistent.json")
+    assert result == []
+
+
+def test_load_tracks_index_malformed_json(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("{ not valid json }", encoding="utf-8")
+    result = usd._load_tracks_index(path)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _update_track_files (integration)
+# ---------------------------------------------------------------------------
+
+def _make_outside_entries(date_prefix: str, count: int = 3) -> list[dict]:
+    return [
+        _make_index_entry(
+            f"{date_prefix}T1{i}:00:00+00:00",
+            lat=OUTSIDE_LAT,
+            lon=OUTSIDE_LON,
+        )
+        for i in range(count)
+    ]
+
+
+def test_update_track_files_creates_gpx(tmp_path):
+    entries = _make_outside_entries("2026-04-11")
+    tracks_dir = tmp_path / "tracks"
+    index_path = tmp_path / "tracks_index.json"
+
+    with patch("scripts.update_signalk_data.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+        mock_dt.fromisoformat = datetime.fromisoformat
+        usd._update_track_files(entries, tracks_dir, index_path, "S.V. Test")
+
+    assert (tracks_dir / "2026-04-11.gpx").exists()
+    assert index_path.exists()
+
+
+def test_update_track_files_skips_harbor_positions(tmp_path):
+    harbor_entry = _make_index_entry("2026-04-11T12:00:00+00:00",
+                                      lat=INSIDE_LAT, lon=INSIDE_LON)
+    tracks_dir = tmp_path / "tracks"
+    index_path = tmp_path / "tracks_index.json"
+
+    with patch("scripts.update_signalk_data.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+        mock_dt.fromisoformat = datetime.fromisoformat
+        usd._update_track_files([harbor_entry], tracks_dir, index_path, "S.V. Test")
+
+    # No GPX should be created — all positions were inside the harbor
+    assert not (tracks_dir / "2026-04-11.gpx").exists()
+    assert not index_path.exists()
+
+
+def test_update_track_files_does_not_overwrite_past_day(tmp_path):
+    entries = _make_outside_entries("2026-03-21")
+    tracks_dir = tmp_path / "tracks"
+    tracks_dir.mkdir()
+    index_path = tmp_path / "tracks_index.json"
+
+    # Pre-create the GPX with sentinel content
+    sentinel = "SENTINEL_CONTENT"
+    (tracks_dir / "2026-03-21.gpx").write_text(sentinel)
+
+    with patch("scripts.update_signalk_data.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+        mock_dt.fromisoformat = datetime.fromisoformat
+        usd._update_track_files(entries, tracks_dir, index_path, "S.V. Test")
+
+    assert (tracks_dir / "2026-03-21.gpx").read_text() == sentinel
+
+
+def test_update_track_files_overwrites_today(tmp_path):
+    entries = _make_outside_entries("2026-04-20")
+    tracks_dir = tmp_path / "tracks"
+    tracks_dir.mkdir()
+    index_path = tmp_path / "tracks_index.json"
+
+    # Pre-create stale content for today
+    (tracks_dir / "2026-04-20.gpx").write_text("OLD_CONTENT")
+
+    with patch("scripts.update_signalk_data.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+        mock_dt.fromisoformat = datetime.fromisoformat
+        usd._update_track_files(entries, tracks_dir, index_path, "S.V. Test")
+
+    content = (tracks_dir / "2026-04-20.gpx").read_text()
+    assert content != "OLD_CONTENT"
+    assert "<?xml" in content
+
+
+def test_update_track_files_index_has_correct_metadata(tmp_path):
+    entries = _make_outside_entries("2026-04-11", count=5)
+    tracks_dir = tmp_path / "tracks"
+    index_path = tmp_path / "tracks_index.json"
+
+    with patch("scripts.update_signalk_data.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+        mock_dt.fromisoformat = datetime.fromisoformat
+        usd._update_track_files(entries, tracks_dir, index_path, "S.V. Test")
+
+    data = json.loads(index_path.read_text())
+    assert "tracks" in data
+    track = data["tracks"][0]
+    assert track["date"] == "2026-04-11"
+    assert track["points"] == 5
+    assert track["file"] == "tracks/2026-04-11.gpx"
+
+
+# ---------------------------------------------------------------------------
+# backfill_tracks._parse_snapshot
+# ---------------------------------------------------------------------------
+
+def test_parse_snapshot_valid_file(tmp_path):
+    path = _make_snapshot_file(tmp_path, "2026-04-11T15:00:00+00:00",
+                                lat=OUTSIDE_LAT, lon=OUTSIDE_LON, speed=3.0, course=1.57)
+    result = bt._parse_snapshot(path)
+    assert result is not None
+    assert result["latitude"] == pytest.approx(OUTSIDE_LAT, abs=1e-4)
+    assert result["longitude"] == pytest.approx(OUTSIDE_LON, abs=1e-4)
+    assert result["speed_ms"] == pytest.approx(3.0, abs=0.01)
+    assert result["course_rad"] == pytest.approx(1.57, abs=0.01)
+    assert result["timestamp"] == "2026-04-11T15:00:00+00:00"
+
+
+def test_parse_snapshot_minimal_no_speed_course(tmp_path):
+    path = _make_snapshot_file(tmp_path, "2026-04-11T15:00:00+00:00",
+                                lat=OUTSIDE_LAT, lon=OUTSIDE_LON)
+    result = bt._parse_snapshot(path)
+    assert result is not None
+    assert result["speed_ms"] is None
+    assert result["course_rad"] is None
+
+
+def test_parse_snapshot_invalid_json(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("{ not json }", encoding="utf-8")
+    assert bt._parse_snapshot(path) is None
+
+
+def test_parse_snapshot_missing_position(tmp_path):
+    payload = {"context": "vessels.self",
+               "updates": [{"timestamp": "2026-04-11T15:00:00+00:00", "values": []}]}
+    path = tmp_path / "2026-04-11T15-00-00.000000Z.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert bt._parse_snapshot(path) is None
+
+
+# ---------------------------------------------------------------------------
+# backfill_tracks.main (end-to-end)
+# ---------------------------------------------------------------------------
+
+def test_backfill_main_creates_gpx_and_index(tmp_path):
+    # Build a fake telemetry directory with a couple of outside-harbor snapshots
+    tel_dir = tmp_path / "telemetry"
+    tel_dir.mkdir()
+    _make_snapshot_file(tel_dir, "2026-03-21T14:00:00+00:00", OUTSIDE_LAT, OUTSIDE_LON, 5.0, 1.0)
+    _make_snapshot_file(tel_dir, "2026-03-21T16:00:00+00:00", OUTSIDE_LAT + 0.01, OUTSIDE_LON, 4.0, 1.1)
+    # Add a harbor position that should be filtered
+    _make_snapshot_file(tel_dir, "2026-03-22T10:00:00+00:00", INSIDE_LAT, INSIDE_LON, 0.1, 0.0)
+
+    tracks_dir = tel_dir / "tracks"
+
+    with (
+        patch("scripts.backfill_tracks.TELEMETRY_DIR", tel_dir),
+        patch("scripts.backfill_tracks.TRACKS_DIR", tracks_dir),
+        patch("scripts.backfill_tracks.TRACKS_INDEX_FILE", tel_dir / "tracks_index.json"),
+        patch("scripts.backfill_tracks.load_vessel_info", return_value={"name": "S.V. Test"}),
+    ):
+        # Patch get_project_root so the script uses our tmp directory
+        with patch("scripts.backfill_tracks.get_project_root", return_value=tmp_path):
+            result = bt.main()
+
+    assert result == 0
+    assert (tracks_dir / "2026-03-21.gpx").exists()
+    # Harbor-only day should not produce a GPX
+    assert not (tracks_dir / "2026-03-22.gpx").exists()
+
+    index = json.loads((tel_dir / "tracks_index.json").read_text())
+    dates = [t["date"] for t in index["tracks"]]
+    assert "2026-03-21" in dates
+    assert "2026-03-22" not in dates
+
+
+def test_backfill_main_does_not_overwrite_existing_gpx(tmp_path):
+    tel_dir = tmp_path / "telemetry"
+    tel_dir.mkdir()
+    _make_snapshot_file(tel_dir, "2026-03-21T14:00:00+00:00", OUTSIDE_LAT, OUTSIDE_LON)
+
+    tracks_dir = tel_dir / "tracks"
+    tracks_dir.mkdir()
+    sentinel = "SENTINEL"
+    (tracks_dir / "2026-03-21.gpx").write_text(sentinel)
+
+    with (
+        patch("scripts.backfill_tracks.TELEMETRY_DIR", tel_dir),
+        patch("scripts.backfill_tracks.TRACKS_DIR", tracks_dir),
+        patch("scripts.backfill_tracks.TRACKS_INDEX_FILE", tel_dir / "tracks_index.json"),
+        patch("scripts.backfill_tracks.load_vessel_info", return_value={"name": "S.V. Test"}),
+        patch("scripts.backfill_tracks.get_project_root", return_value=tmp_path),
+    ):
+        bt.main()
+
+    assert (tracks_dir / "2026-03-21.gpx").read_text() == sentinel


### PR DESCRIPTION
Root cause: positions_index.json has a 24-day retention window, and most
days within that window the boat is docked (filtered by harbor geofence),
so the History→All filter could only ever show a handful of sailing days
instead of the full trip history.

Fix: generate a permanent per-day GPX file for every sailing day — no
retention limit. The live positions_index.json keeps its 24-day window for
real-time rendering; the GPX layer adds the long-term archive.

- update_signalk_data.py: emit data/telemetry/tracks/YYYY-MM-DD.gpx and
  tracks_index.json on each update cycle using Garmin TrackPointExtension
  v1 (speed m/s + course °) so files are plotter/JibSet-ready out of the box
- scripts/backfill_tracks.py: one-time backfill from all snapshot files;
  recovered 16 sailing days going back to 2026-02-28
- app.js: load tracks_index.json on startup, fetch GPX files for historical
  days not covered by positions_index, merge into trackByDay so History→All
  now shows the complete record; add ↓ download link per day in the legend
- styles.css: style for the GPX download link

https://claude.ai/code/session_011Kbc3NXxpgVzmq1X9akNGZ