### PR TITLE
Use MarineTraffic ship ID for vessel link, remove MyShipTracking

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -855,23 +855,18 @@ function updateVesselLinks() {
     vesselData.signalk.websocket_url = `${wsUrl}/signalk/v1/stream`;
   }
 
-  // Construct external tracking links using MMSI
-  if (vesselData.mmsi) {
+  // Construct external tracking links
+  if (vesselData.marinetraffic_ship_id) {
     vesselData.links = {
-      marinetraffic: `https://www.marinetraffic.com/en/ais/details/ships/mmsi:${vesselData.mmsi}`,
-      myshiptracking: `https://www.myshiptracking.com/vessels/mmsi-${vesselData.mmsi}`
+      marinetraffic: `https://www.marinetraffic.com/en/ais/details/ships/shipid:${vesselData.marinetraffic_ship_id}`
     };
   }
 
   // Update AIS links
   const marinetrafficLink = document.getElementById('marinetraffic-link');
-  const myshiptrackingLink = document.getElementById('myshiptracking-link');
 
   if (marinetrafficLink && vesselData.links?.marinetraffic) {
     marinetrafficLink.href = vesselData.links.marinetraffic;
-  }
-  if (myshiptrackingLink && vesselData.links?.myshiptracking) {
-    myshiptrackingLink.href = vesselData.links.myshiptracking;
   }
 }
 let themeChangeTimeout = null; // Timeout for theme change debouncing

--- a/data/vessel/info.yaml
+++ b/data/vessel/info.yaml
@@ -8,6 +8,7 @@
 theme: "mermug"   # light | dark | mermug | deep-sea | starboard | port-light | midnight-watch | chart-room | fog-bank | overcast | coral | kelp | dusk
 name: "S.V.Mermug"
 mmsi: "338543654"
+marinetraffic_ship_id: "9698083"
 uscg_number: "1024168"
 hull_number: "BEY57004E494"
 signalk:

--- a/index.html
+++ b/index.html
@@ -45,7 +45,6 @@
     <div class="links-section">
       <div class="button-row">
         <a href="#" id="marinetraffic-link" target="_blank" class="action-btn ais-btn">MarineTraffic</a>
-        <a href="#" id="myshiptracking-link" target="_blank" class="action-btn ais-btn">MyShipTracking</a>
       </div>
     </div>
 

--- a/scripts/vessel_config_wizard.py
+++ b/scripts/vessel_config_wizard.py
@@ -56,6 +56,7 @@ class VesselConfigWizard:
         return {
             "name": "S.V. Vessel",
             "mmsi": "123456789",
+            "marinetraffic_ship_id": "",
             "uscg_number": "1234567",
             "hull_number": "ABC12345",
             "signalk": {"host": "192.168.1.100", "port": "3000", "protocol": "https"},
@@ -186,6 +187,11 @@ class VesselConfigWizard:
 
         self.config["mmsi"] = self.get_input(
             "MMSI (Maritime Mobile Service Identity)", self.config.get("mmsi", "")
+        )
+
+        self.config["marinetraffic_ship_id"] = self.get_input(
+            "MarineTraffic ship ID (find at marinetraffic.com, e.g. shipid:XXXXXXX in the URL)",
+            self.config.get("marinetraffic_ship_id", ""),
         )
 
         self.config["uscg_number"] = self.get_input(


### PR DESCRIPTION
Adds marinetraffic_ship_id to info.yaml and updates the link to use
shipid: format since MMSI-based MarineTraffic URLs don't resolve reliably.
Removes the MyShipTracking button.

https://claude.ai/code/session_01F4ArLqhzbLxRPbn1G4nUdv