### PR TITLE
Clean up Makefile and fix stale README docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,50 +2,48 @@
 .PHONY: install-website-service uninstall-website-service check-service-status-website show-logs-website run-website-update
 .PHONY: install-polars-service uninstall-polars-service check-service-status-polars show-logs-polars run-polar-update
 
-# Default target
 .DEFAULT_GOAL := help
 
-# System check
 UNAME_S := $(shell uname -s)
 
-# Core configuration
 SERVER_PORT ?= 8000
 SIGNALK_HOST ?= 192.168.8.50
 SIGNALK_PORT ?= 3000
 UV_BIN ?= $(shell command -v uv 2>/dev/null || true)
 CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo main)
 
-# Service management functions
+# Install a systemd service from a template.
+# Args: (1) service name, (2) description, (3) python module, (4) module args, (5) restart sec, (6) template path
 define install-service
-	@echo "Installing $(2) systemd service..."
-	@if [ -f "/etc/systemd/system/$(2).service" ]; then \
-		echo "$(2) service already exists. Uninstalling first..."; \
-		sudo systemctl stop $(2) 2>/dev/null || true; \
-		sudo systemctl disable $(2) 2>/dev/null || true; \
+	@echo "Installing $(1) systemd service..."
+	@if [ -f "/etc/systemd/system/$(1).service" ]; then \
+		echo "$(1) service already exists. Uninstalling first..."; \
+		sudo systemctl stop $(1) 2>/dev/null || true; \
+		sudo systemctl disable $(1) 2>/dev/null || true; \
 	fi
 	@if [ -z "$(UV_BIN)" ]; then \
 		echo "Error: 'uv' is not installed. Please install uv first."; \
 		echo "Visit: https://github.com/astral-sh/uv"; \
 		exit 1; \
 	fi
-	@echo "Rendering $(2) service template..."
-	@sed -e "s|{{DESCRIPTION}}|$(3)|g" \
+	@echo "Rendering $(1) service template..."
+	@sed -e "s|{{DESCRIPTION}}|$(2)|g" \
 		-e "s|{{USER}}|$$(whoami)|g" \
 		-e "s|{{WORKING_DIRECTORY}}|$(CURDIR)|g" \
-		-e "s|{{EXEC_START}}|$(UV_BIN) run python -m $(4) $(5)|g" \
+		-e "s|{{EXEC_START}}|$(UV_BIN) run python -m $(3) $(4)|g" \
 		-e "s|{{RESTART_POLICY}}|always|g" \
-		-e "s|{{RESTART_SEC}}|$(6)|g" \
+		-e "s|{{RESTART_SEC}}|$(5)|g" \
 		-e "s|{{GIT_BRANCH}}|$(CURRENT_BRANCH)|g" \
 		-e "s|{{GIT_REMOTE}}|origin|g" \
 		-e "s|{{SIGNALK_URL}}|http://$(SIGNALK_HOST):$(SIGNALK_PORT)/signalk/v1/api/vessels/self|g" \
 		-e "s|{{OUTPUT_FILE}}|data/telemetry/signalk_latest.json|g" \
-		"$(CURDIR)/services/systemd.service.tpl" | sudo tee /etc/systemd/system/$(2).service > /dev/null
+		"$(6)" | sudo tee /etc/systemd/system/$(1).service > /dev/null
 	@echo "Reloading systemd..."
 	@sudo systemctl daemon-reload
-	@echo "Enabling and starting $(2) service..."
-	@sudo systemctl enable $(2)
-	@sudo systemctl start $(2)
-	@echo "$(2) service installed and started successfully!"
+	@echo "Enabling and starting $(1) service..."
+	@sudo systemctl enable $(1)
+	@sudo systemctl start $(1)
+	@echo "$(1) service installed and started successfully!"
 endef
 
 define uninstall-service
@@ -73,17 +71,15 @@ define check-service-status
 		sudo systemctl status $(1) --no-pager -l; \
 	else \
 		echo "$(1) service file not found at /etc/systemd/system/$(1).service"; \
-		echo "$(1) service is not installed. Run 'make install-$(2)-service' to install it."; \
+		echo "$(1) service is not installed. Run 'make install' to install it."; \
 	fi
 endef
 
 define show-service-logs
-	@echo "Showing logs for $(1) service..."
-	@echo "Press Ctrl+C to exit logs"
+	@echo "Showing logs for $(1) service (Ctrl+C to exit)..."
 	@sudo journalctl -u $(1) -f
 endef
 
-# Check Linux requirement
 check-linux:
 	@if [ "$(UNAME_S)" != "Linux" ]; then \
 		echo "Error: This command only works on Linux systems"; \
@@ -91,39 +87,37 @@ check-linux:
 		exit 1; \
 	fi
 
-
-# Default target
 help:
-	@echo "Installation and General Usage:"
-	@echo "  make install        - Install all services (website, polars)"
-	@echo "  make uninstall      - Uninstall all services (Linux only)"
-	@echo "  make status         - Reports website and polars service statuses"
-	@echo "  make config        - Interactive vessel configuration wizard"
-	@echo "  make help          - Show this help message"
+	@echo "General:"
+	@echo "  make install                    - Install all system services (Linux only)"
+	@echo "  make uninstall                  - Remove all system services (Linux only)"
+	@echo "  make status                     - Report website and polars service statuses"
+	@echo "  make config                     - Interactive vessel configuration wizard"
 	@echo ""
-	@echo "Development Commands:"
-	@echo "  make server         - Start Python HTTP server on port $(SERVER_PORT)"
-	@echo "  make test           - Run Python and JavaScript test suites"
-	@echo "  make test-js        - Run JavaScript unit tests (vitest)"
-	@echo "  make js-install     - Install JavaScript dependencies (npm)"
-	@echo "  make pre-commit-install - Install pre-commit hooks (requires uv)"
-	@echo "  make lint          - Run ruff linter and auto-fix issues on all Python files"
-	@echo "  make run-website-update       - Run one website telemetry update now"
-	@echo "  make run-polar-update         - Run one polar accumulation sample now"
+	@echo "Development:"
+	@echo "  make server                     - Start local HTTP server on port $(SERVER_PORT)"
+	@echo "  make test                       - Run Python and JavaScript test suites"
+	@echo "  make test-py                    - Run Python tests (pytest)"
+	@echo "  make test-js                    - Run JavaScript tests (vitest)"
+	@echo "  make js-install                 - Install JavaScript dependencies (npm)"
+	@echo "  make lint                       - Run ruff linter with auto-fix"
+	@echo "  make sync-dev                   - Sync dev Python dependencies"
+	@echo "  make pre-commit-install         - Install pre-commit hooks"
+	@echo ""
+	@echo "Manual execution:"
+	@echo "  make run-website-update         - Fetch SignalK data once"
+	@echo "  make run-polar-update           - Run one polar accumulation sample"
 	@echo ""
 	@echo "Service management:"
 	@echo "  make install-website-service    - Install website data updater service"
-	@echo "  make install-polars-service     - Install polar accumulation service (10s)"
-	@echo "  make uninstall-website-service  - Uninstall website service"
+	@echo "  make install-polars-service     - Install polar accumulation service"
+	@echo "  make uninstall-website-service  - Uninstall website updater service"
 	@echo "  make uninstall-polars-service   - Uninstall polar accumulation service"
 	@echo "  make check-service-status-website - Check website service status"
 	@echo "  make check-service-status-polars  - Check polar accumulation service status"
-	@echo ""
-	@echo "Logs:"
-	@echo "  make show-logs-website             - Show website service logs"
-	@echo "  make show-logs-polars              - Show polar accumulation service logs"
+	@echo "  make show-logs-website          - Stream website service logs"
+	@echo "  make show-logs-polars           - Stream polar accumulation service logs"
 
-# Start Python HTTP server
 server:
 	@echo "Open http://localhost:$(SERVER_PORT) in your browser"
 	@echo "Press Ctrl+C to stop the server"
@@ -132,10 +126,8 @@ server:
 		echo "Visit: https://github.com/astral-sh/uv"; \
 		exit 1; \
 	fi
-	@echo "Starting server with uv environment: $(UV_BIN)"
 	@"$(UV_BIN)" run python -m http.server $(SERVER_PORT)
 
-# Install all services
 install: check-linux
 	@if [ -z "$(UV_BIN)" ]; then \
 		echo "Error: 'uv' is not installed. Please install uv first."; \
@@ -143,18 +135,12 @@ install: check-linux
 		exit 1; \
 	fi
 	@echo "Installing all vessel tracker services..."
-	@echo ""
-	@echo "This will install:"
-	@echo "  - Website data updater service"
-	@echo "  - Polar accumulation service"
-	@echo ""
 	@$(MAKE) install-website-service
 	@echo ""
 	@$(MAKE) install-polars-service
 	@echo ""
 	@echo "All services installed successfully!"
 
-# Uninstall all services
 uninstall: check-linux
 	@echo "Uninstalling all vessel tracker services..."
 	@$(MAKE) uninstall-website-service
@@ -163,73 +149,30 @@ uninstall: check-linux
 	@echo ""
 	@echo "All services uninstalled successfully!"
 
-# Individual service installation
 install-website-service: check-linux
-	@if [ -z "$(UV_BIN)" ]; then \
-		echo "Error: 'uv' is not installed. Please install uv first."; \
-		echo "Visit: https://github.com/astral-sh/uv"; \
-		exit 1; \
-	fi
-	$(call install-service,website,vesselwebsite,Vessel Tracker Data Updater,scripts.update_signalk_data,--interval 150,150)
+	$(call install-service,vesselwebsite,Vessel Tracker Data Updater,scripts.update_signalk_data,--interval 150,150,$(CURDIR)/services/systemd.service.tpl)
 
 install-polars-service: check-linux
-	@if [ -z "$(UV_BIN)" ]; then \
-		echo "Error: 'uv' is not installed. Please install uv first."; \
-		echo "Visit: https://github.com/astral-sh/uv"; \
-		exit 1; \
-	fi
-	@echo "Installing polar accumulation service..."
-	@if [ -f "/etc/systemd/system/vesselpolars.service" ]; then \
-		echo "vesselpolars service already exists. Uninstalling first..."; \
-		sudo systemctl stop vesselpolars 2>/dev/null || true; \
-		sudo systemctl disable vesselpolars 2>/dev/null || true; \
-	fi
-	@sed -e "s|{{DESCRIPTION}}|Vessel Polar Performance Accumulator|g" \
-		-e "s|{{USER}}|$$(whoami)|g" \
-		-e "s|{{WORKING_DIRECTORY}}|$(CURDIR)|g" \
-		-e "s|{{EXEC_START}}|$(UV_BIN) run python -m scripts.update_polar_data --interval 10|g" \
-		-e "s|{{SIGNALK_URL}}|http://$(SIGNALK_HOST):$(SIGNALK_PORT)/signalk/v1/api/vessels/self|g" \
-		"$(CURDIR)/services/polars.service.tpl" | sudo tee /etc/systemd/system/vesselpolars.service > /dev/null
-	@echo "Reloading systemd..."
-	@sudo systemctl daemon-reload
-	@echo "Enabling and starting vesselpolars service..."
-	@sudo systemctl enable vesselpolars
-	@sudo systemctl start vesselpolars
-	@echo "vesselpolars service installed and started successfully!"
+	$(call install-service,vesselpolars,Vessel Polar Performance Accumulator,scripts.update_polar_data,--interval 10,15,$(CURDIR)/services/polars.service.tpl)
+
+uninstall-website-service: check-linux
+	$(call uninstall-service,vesselwebsite)
 
 uninstall-polars-service: check-linux
 	$(call uninstall-service,vesselpolars)
 
-check-service-status-polars: check-linux
-	$(call check-service-status,vesselpolars,polars)
-
-show-logs-polars: check-linux
-	$(call show-service-logs,vesselpolars)
-
-run-polar-update:
-	@if [ -z "$(UV_BIN)" ]; then \
-		echo "Error: 'uv' is not installed. Please install uv first."; \
-		echo "Visit: https://github.com/astral-sh/uv"; \
-		exit 1; \
-	fi
-	@echo "Running one polar accumulation sample..."
-	"$(UV_BIN)" run python -m scripts.update_polar_data --interval 0 --signalk-url "http://$(SIGNALK_HOST):$(SIGNALK_PORT)/signalk/v1/api/vessels/self"
-
-# Individual service uninstallation
-uninstall-website-service: check-linux
-	$(call uninstall-service,vesselwebsite)
-
-# Service status checking
 check-service-status-website: check-linux
-	$(call check-service-status,vesselwebsite,website)
+	$(call check-service-status,vesselwebsite)
 
-# Report service statuses
+check-service-status-polars: check-linux
+	$(call check-service-status,vesselpolars)
+
 status: check-linux
 	@echo "=========================================="
 	@echo "Vessel Tracker Status Report"
 	@echo "=========================================="
 	@echo ""
-	@echo "--- Website Service Status ---"
+	@echo "--- Website Service ---"
 	@if [ -f "/etc/systemd/system/vesselwebsite.service" ]; then \
 		echo "Service: vesselwebsite"; \
 		sudo systemctl is-active vesselwebsite >/dev/null 2>&1 && echo "Status: ✓ Active" || echo "Status: ✗ Inactive"; \
@@ -238,7 +181,7 @@ status: check-linux
 		echo "Status: ✗ Not installed"; \
 	fi
 	@echo ""
-	@echo "--- Polar Accumulation Service Status ---"
+	@echo "--- Polar Accumulation Service ---"
 	@if [ -f "/etc/systemd/system/vesselpolars.service" ]; then \
 		echo "Service: vesselpolars"; \
 		sudo systemctl is-active vesselpolars >/dev/null 2>&1 && echo "Status: ✓ Active" || echo "Status: ✗ Inactive"; \
@@ -249,11 +192,12 @@ status: check-linux
 	@echo ""
 	@echo "=========================================="
 
-# Service logs
 show-logs-website: check-linux
 	$(call show-service-logs,vesselwebsite)
 
-# Run one website telemetry update (single execution)
+show-logs-polars: check-linux
+	$(call show-service-logs,vesselpolars)
+
 run-website-update:
 	@if [ -z "$(UV_BIN)" ]; then \
 		echo "Error: 'uv' is not installed. Please install uv first."; \
@@ -261,10 +205,17 @@ run-website-update:
 		exit 1; \
 	fi
 	@echo "Running one website telemetry update..."
-	@echo "Fetching from SignalK and writing data..."
-	"$(UV_BIN)" run python -m scripts.update_signalk_data --signalk-url "http://$(SIGNALK_HOST):$(SIGNALK_PORT)/signalk/v1/api/vessels/self" --output data/telemetry/signalk_latest.json
+	@"$(UV_BIN)" run python -m scripts.update_signalk_data --signalk-url "http://$(SIGNALK_HOST):$(SIGNALK_PORT)/signalk/v1/api/vessels/self" --output data/telemetry/signalk_latest.json
 
-# Run tests
+run-polar-update:
+	@if [ -z "$(UV_BIN)" ]; then \
+		echo "Error: 'uv' is not installed. Please install uv first."; \
+		echo "Visit: https://github.com/astral-sh/uv"; \
+		exit 1; \
+	fi
+	@echo "Running one polar accumulation sample..."
+	@"$(UV_BIN)" run python -m scripts.update_polar_data --interval 0 --signalk-url "http://$(SIGNALK_HOST):$(SIGNALK_PORT)/signalk/v1/api/vessels/self"
+
 test: test-py test-js
 
 test-py:
@@ -273,7 +224,7 @@ test-py:
 		echo "Visit: https://github.com/astral-sh/uv"; \
 		exit 1; \
 	fi
-	@echo "Running Python tests inside uv-managed virtualenv..."
+	@echo "Running Python tests..."
 	@PYTHONPATH="$(CURDIR):$(CURDIR)/scripts" "$(UV_BIN)" run pytest -q
 
 test-js:
@@ -294,7 +245,6 @@ js-install:
 	fi
 	@npm install
 
-# Install pre-commit hooks
 pre-commit-install:
 	@if [ -z "$(UV_BIN)" ]; then \
 		echo "Error: 'uv' is not installed. Please install uv first."; \
@@ -302,32 +252,17 @@ pre-commit-install:
 		exit 1; \
 	fi
 	@echo "Installing pre-commit hooks..."
-	@if command -v uvx >/dev/null 2>&1; then \
-		echo "Installing with uvx..."; \
-		uvx pre-commit install; \
-	else \
-		echo "Error: 'uvx' is not available. Ensure 'uv' is installed and on PATH."; \
-		exit 1; \
-	fi
+	@uvx pre-commit install
 
-
-# Run ruff linter and auto-fix issues on all Python files
 lint:
 	@if [ -z "$(UV_BIN)" ]; then \
 		echo "Error: 'uv' is not installed. Please install uv first."; \
 		echo "Visit: https://github.com/astral-sh/uv"; \
 		exit 1; \
 	fi
-	@echo "Running ruff linter with auto-fix on all Python files (uvx)..."
-	@if command -v uvx >/dev/null 2>&1; then \
-		echo "Running with uvx..."; \
-		uvx ruff check --fix .; \
-	else \
-		echo "Error: 'uvx' is not available. Ensure 'uv' is installed and on PATH."; \
-		exit 1; \
-	fi
+	@echo "Running ruff linter with auto-fix..."
+	@uvx ruff check --fix .
 
-# Sync dev dependencies
 sync-dev:
 	@if [ -z "$(UV_BIN)" ]; then \
 		echo "Error: 'uv' is not installed. Please install uv first."; \
@@ -337,7 +272,11 @@ sync-dev:
 	@echo "Syncing dev dependencies..."
 	@"$(UV_BIN)" sync --extra dev
 
-# Interactive vessel configuration wizard
 config:
+	@if [ -z "$(UV_BIN)" ]; then \
+		echo "Error: 'uv' is not installed. Please install uv first."; \
+		echo "Visit: https://github.com/astral-sh/uv"; \
+		exit 1; \
+	fi
 	@echo "Starting Vessel Configuration Wizard..."
 	@"$(UV_BIN)" run python -m scripts.vessel_config_wizard

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Data freshness depends on the Pi's update interval and internet connectivity fro
 ```bash
 git clone <repository-url>
 cd zackphillips.github.io
-make check-uv
 make pre-commit-install
 ```
 
@@ -70,11 +69,11 @@ This runs an interactive wizard that writes `data/vessel/info.yaml` with your ve
 ### Run as a system service
 
 ```bash
-make install-service          # Install and start the updater as a systemd service
-make check-service-status     # Check it's running
-make logs                     # Stream live logs
-make change-server-update-period RESTART_SEC=300  # Change update interval (seconds)
-make uninstall-service        # Remove the service
+make install              # Install and start all services
+make status               # Check service statuses
+make show-logs-website    # Stream website service logs
+make show-logs-polars     # Stream polar accumulation service logs
+make uninstall            # Remove all services
 ```
 
 ---
@@ -82,9 +81,9 @@ make uninstall-service        # Remove the service
 ## Development
 
 ```bash
-make server       # Local dev server at http://localhost:8000
-make test         # Run Python + JavaScript tests
-make pre-commit-run  # Run linters and formatters
+make server    # Local dev server at http://localhost:8000
+make test      # Run Python + JavaScript tests
+make lint      # Run ruff linter and auto-fix
 ```
 
 ### Tech stack


### PR DESCRIPTION
- Remove unused first parameter from install-service define (was never referenced in the body)
- Consolidate install-polars-service to use the shared install-service define instead of duplicating all template-rendering logic inline; add template path as new parameter to the define
- Remove second parameter from check-service-status define and update the "not installed" hint to point to `make install`
- Remove redundant uvx availability checks in pre-commit-install and lint (uvx is always present when uv is installed)
- Add missing uv guard to config target
- Align and complete help text: add test-py, sync-dev, fix column alignment
- Fix README: remove nonexistent make check-uv, make install-service, make logs, make change-server-update-period, make uninstall-service, make pre-commit-run; replace with correct current commands

https://claude.ai/code/session_01D92PUgKNRMWUsJXVoa8dDQ