### PR TITLE
Voyage stats, privacy zones, OG tags, service worker, constants, instrument log

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1339,77 +1339,36 @@ async function loadData() {
     return description;
   };
 
-  const toSnapshotFilename = (timestamp) => {
-    if (!timestamp) return null;
-    const normalized = timestamp.replace('Z', '+00:00');
-    const datePart = normalized.split('+')[0];
-    if (!datePart) return null;
-    return `${datePart.replace(/:/g, '-')}Z.json`;
-  };
-
-  const buildSeriesFromSnapshots = (snapshots) => {
+  // Build a Map<path, [{t, v}]> from instrument_log.json entries.
+  // Each entry is {timestamp, values: {path: number}}.
+  const buildSeriesFromLog = (entries) => {
     const map = new Map();
-    for (const snapshot of snapshots) {
-      if (!snapshot || typeof snapshot !== 'object') continue;
-
-      // Support both formats:
-      //   New: SignalK delta  → { context, updates: [{ timestamp, values: [{path, value}] }] }
-      //   Legacy:             → { timestamp, numericValues: { path: value } }
-      const update = snapshot.updates?.[0];
-      const timestamp = update?.timestamp || snapshot.timestamp || snapshot.time || null;
-      const date = timestamp ? new Date(timestamp) : null;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== 'object') continue;
+      const date = entry.timestamp ? new Date(entry.timestamp) : null;
       if (!date || Number.isNaN(date.getTime())) continue;
-
-      if (Array.isArray(update?.values)) {
-        // New SignalK format
-        for (const { path, value } of update.values) {
-          if (typeof value === 'number' && Number.isFinite(value)) {
-            const list = map.get(path) || [];
-            list.push({ t: date, v: value });
-            map.set(path, list);
-          }
-        }
-      } else {
-        // Legacy numericValues format
-        const values = snapshot.numericValues;
-        if (!values || typeof values !== 'object') continue;
-        Object.entries(values).forEach(([path, value]) => {
-          if (typeof value !== 'number' || !Number.isFinite(value)) return;
-          const list = map.get(path) || [];
-          list.push({ t: date, v: value });
-          map.set(path, list);
-        });
+      const values = entry.values;
+      if (!values || typeof values !== 'object') continue;
+      for (const [path, value] of Object.entries(values)) {
+        if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+        const list = map.get(path) || [];
+        list.push({ t: date, v: value });
+        map.set(path, list);
       }
     }
-    for (const list of map.values()) {
-      list.sort((a, b) => a.t - b.t);
-    }
+    for (const list of map.values()) list.sort((a, b) => a.t - b.t);
     return map;
   };
 
   const loadSeries = async () => {
     if (seriesByPath) return seriesByPath;
     if (seriesPromise) return seriesPromise;
-    seriesPromise = fetch(`${SNAPSHOT_INDEX_URL}?ts=${Date.now()}`)
+    seriesPromise = fetch(`${C.INSTRUMENT_LOG_URL}?ts=${Date.now()}`)
       .then((res) => (res.ok ? res.json() : null))
-      .then(async (payload) => {
-        const positions = Array.isArray(payload) ? payload : payload?.positions;
-        if (!Array.isArray(positions) || !positions.length) {
-          seriesByPath = new Map();
-          return seriesByPath;
-        }
-        const recent = positions.slice(-SPARKLINE_POINTS);
-        const files = recent
-          .map((entry) => entry?.file || toSnapshotFilename(entry?.timestamp))
-          .filter(Boolean);
-        const snapshots = await Promise.all(
-          files.map((file) =>
-            fetch(`data/telemetry/${file}?ts=${Date.now()}`)
-              .then((res) => (res.ok ? res.json() : null))
-              .catch(() => null)
-          )
-        );
-        seriesByPath = buildSeriesFromSnapshots(snapshots);
+      .then((payload) => {
+        const entries = Array.isArray(payload?.entries) ? payload.entries : [];
+        const recent = entries.slice(-SPARKLINE_POINTS);
+        seriesByPath = buildSeriesFromLog(recent);
         return seriesByPath;
       })
       .catch(() => {

--- a/assets/app.js
+++ b/assets/app.js
@@ -2,6 +2,10 @@ const vesselUtils = window.vesselUtils;
 if (!vesselUtils) {
   throw new Error('vesselUtils must be loaded before app.js');
 }
+if (!window.VESSEL_CONSTANTS) {
+  throw new Error('constants.js must be loaded before app.js');
+}
+const C = window.VESSEL_CONSTANTS;
 const { haversine, getAnchorDistanceColor, getWindDirection } = vesselUtils;
 
 Chart.defaults.font.family = 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif';
@@ -25,7 +29,7 @@ let anchorLayer = null;    // Leaflet circle for anchor swing radius
 let anchorMarker = null;   // ⚓ icon at anchor drop position
 let anchorLine = null;     // dashed line from anchor to vessel
 let trackLegend = null;    // Leaflet control for day-colour legend
-let recentTrackCount = 3;      // Number of most-recent tracks to colour (rest shown pale white)
+let recentTrackCount = C.DEFAULT_RECENT_TRACK_COUNT; // Number of most-recent tracks to colour (rest shown pale white)
 let trackByDay = new Map();    // Cached track data keyed by YYYY-MM-DD (local)
 let tracksIndex = [];          // Metadata from tracks_index.json (all sailing days ever)
 let olderTrackLayer = null;    // Leaflet layer for older tracks shown in white
@@ -50,9 +54,9 @@ function setCached(key, data) {
 }
 let tideStations = null; // Global tide stations data
 const DEFAULT_TIDE_LOCATION = {
-  lat: 37.806,
-  lon: -122.465,
-  label: 'San Francisco Bay',
+  lat:   C.DEFAULT_TIDE_LAT,
+  lon:   C.DEFAULT_TIDE_LON,
+  label: C.DEFAULT_TIDE_LABEL,
 };
 
 const PANEL_SKELETONS = {
@@ -69,44 +73,44 @@ const PANEL_SKELETONS = {
 
 function classifyBatteryStatus(percent) {
   if (!Number.isFinite(percent)) return null;
-  if (percent >= 75) return { level: 'ok', label: 'Charged' };
-  if (percent >= 45) return { level: 'warn', label: 'Low' };
+  if (percent >= C.BATTERY_OK_PCT)   return { level: 'ok',    label: 'Charged' };
+  if (percent >= C.BATTERY_WARN_PCT) return { level: 'warn',  label: 'Low' };
   return { level: 'alert', label: 'Critical' };
 }
 
 function classifyBatteryTime(hours) {
   if (!Number.isFinite(hours)) return null;
-  if (hours >= 6) return { level: 'ok', label: 'Plenty' };
-  if (hours >= 2) return { level: 'warn', label: 'Soon' };
+  if (hours >= C.BATTERY_TIME_OK_H)   return { level: 'ok',   label: 'Plenty' };
+  if (hours >= C.BATTERY_TIME_WARN_H) return { level: 'warn', label: 'Soon' };
   return { level: 'alert', label: 'Short' };
 }
 
 function classifyAnchorStatus(current, max) {
   if (!Number.isFinite(current) || !Number.isFinite(max) || max <= 0) return null;
-  if (current <= max * 0.85) return { level: 'ok', label: 'Safe' };
-  if (current <= max * 1.05) return { level: 'warn', label: 'Edge' };
+  if (current <= max * C.ANCHOR_WARN_RATIO) return { level: 'ok',   label: 'Safe' };
+  if (current <= max * C.ANCHOR_EDGE_RATIO) return { level: 'warn', label: 'Edge' };
   return { level: 'alert', label: 'Drifting' };
 }
 
 function classifyPacketLoss(loss) {
   if (!Number.isFinite(loss)) return null;
   const percentage = loss <= 1 ? loss * 100 : loss;
-  if (percentage < 1) return { level: 'ok', label: 'Clean' };
-  if (percentage < 3) return { level: 'warn', label: 'Lossy' };
+  if (percentage < C.PACKET_LOSS_OK_PCT)   return { level: 'ok',   label: 'Clean' };
+  if (percentage < C.PACKET_LOSS_WARN_PCT) return { level: 'warn', label: 'Lossy' };
   return { level: 'alert', label: 'Dropping' };
 }
 
 function classifyTankLevel(level) {
   if (!Number.isFinite(level)) return null;
-  if (level >= 0.35) return { level: 'ok', label: 'Healthy' };
-  if (level >= 0.2) return { level: 'warn', label: 'Low' };
+  if (level >= C.TANK_OK_RATIO)   return { level: 'ok',   label: 'Healthy' };
+  if (level >= C.TANK_WARN_RATIO) return { level: 'warn', label: 'Low' };
   return { level: 'alert', label: 'Refill' };
 }
 
 function classifyWasteTank(level) {
   if (!Number.isFinite(level)) return null;
-  if (level <= 0.4) return { level: 'ok', label: 'Clear' };
-  if (level <= 0.7) return { level: 'warn', label: 'Rising' };
+  if (level <= C.WASTE_WARN_RATIO)  return { level: 'ok',   label: 'Clear' };
+  if (level <= C.WASTE_ALERT_RATIO) return { level: 'warn', label: 'Rising' };
   return { level: 'alert', label: 'Full' };
 }
 
@@ -222,11 +226,11 @@ function renderEmptyState(containerId, title, subtitle = '') {
 
 async function updateMapLocation(lat, lon) {
   try {
-    // If inside the harbor geofence, look up the geofence center so we get a
-    // proper landmark name instead of an open-water result.
-    const inHarbor = haversineMeters(lat, lon, HARBOR_CENTER_LAT, HARBOR_CENTER_LON) <= HARBOR_RADIUS_M;
-    const lookupLat = inHarbor ? HARBOR_CENTER_LAT : lat;
-    const lookupLon = inHarbor ? HARBOR_CENTER_LON : lon;
+    // If inside a privacy zone, snap the geocoding lookup to the zone center
+    // so we get a proper landmark name rather than an open-water coordinate.
+    const zone = getPrivacyZoneCenter(lat, lon);
+    const lookupLat = zone ? zone.lat : lat;
+    const lookupLon = zone ? zone.lon : lon;
     const response = await fetch(`https://nominatim.openstreetmap.org/reverse?lat=${lookupLat}&lon=${lookupLon}&format=json&zoom=10&addressdetails=1`);
     const data = await response.json();
 
@@ -279,9 +283,30 @@ const DAY_TRACK_COLORS = [
   '#009688', '#2196f3', '#ff4081', '#76ff03', '#40c4ff', '#ea80fc',
 ];
 
-const HARBOR_CENTER_LAT = 37.7802069;
-const HARBOR_CENTER_LON = -122.3858040;
-const HARBOR_RADIUS_M = 200;
+// Privacy zones — populated from vesselData.privacy_zones after YAML loads.
+// Falls back to the South Beach Harbor constant when vesselData is unavailable.
+function getPrivacyZones() {
+  const zones = vesselData?.privacy_zones;
+  if (Array.isArray(zones) && zones.length) return zones;
+  return [{
+    lat:      C.FALLBACK_PRIVACY_ZONE_LAT,
+    lon:      C.FALLBACK_PRIVACY_ZONE_LON,
+    radius_m: C.FALLBACK_PRIVACY_ZONE_RADIUS_M,
+  }];
+}
+
+function isInPrivacyZone(lat, lon) {
+  return getPrivacyZones().some(
+    (z) => haversineMeters(lat, lon, z.lat, z.lon) <= z.radius_m
+  );
+}
+
+// Return the center of the first zone containing (lat, lon), or null.
+function getPrivacyZoneCenter(lat, lon) {
+  return getPrivacyZones().find(
+    (z) => haversineMeters(lat, lon, z.lat, z.lon) <= z.radius_m
+  ) ?? null;
+}
 
 function haversineMeters(lat1, lon1, lat2, lon2) {
   const R = 6371000;
@@ -507,7 +532,7 @@ async function loadTrack() {
       .filter((p) => p
         && Number.isFinite(p.latitude)
         && Number.isFinite(p.longitude)
-        && haversineMeters(p.latitude, p.longitude, HARBOR_CENTER_LAT, HARBOR_CENTER_LON) > HARBOR_RADIUS_M);
+        && !isInPrivacyZone(p.latitude, p.longitude));
 
     if (!positions.length) return;
 
@@ -630,8 +655,8 @@ let currentNav = null; // Global navigation data
 let currentPropulsion = null; // Global propulsion data
 let isDrawingPolarChart = false; // Flag to prevent multiple simultaneous chart draws
 let lastPolarChartUpdate = 0; // Timestamp of last chart update
-const SNAPSHOT_INDEX_URL = 'data/telemetry/snapshots_index.json';
-const SPARKLINE_POINTS = 60;
+const SNAPSHOT_INDEX_URL = C.SNAPSHOT_INDEX_URL;
+const SPARKLINE_POINTS = C.SPARKLINE_POINTS;
 let seriesByPath = null;
 let seriesPromise = null;
 let refreshSparklines = null; // set once initInlineSparklines is ready
@@ -755,6 +780,51 @@ function resolveTidePosition(currentLat, currentLon) {
   };
 }
 
+// ── Voyage statistics ────────────────────────────────────────────────────────
+
+async function loadVoyageStats() {
+  const panel = document.getElementById('voyage-stats-panel');
+  if (!panel) return;
+
+  try {
+    const resp = await fetch(`${C.TRACKS_INDEX_URL}?ts=${Date.now()}`);
+    if (!resp.ok) { panel.style.display = 'none'; return; }
+    const data = await resp.json();
+    const tracks = Array.isArray(data) ? data : (data.tracks ?? []);
+    if (!tracks.length) { panel.style.display = 'none'; return; }
+
+    const totalDays     = tracks.length;
+    const totalNm       = tracks.reduce((s, t) => s + (t.distance_nm  ?? 0), 0);
+    const totalHours    = tracks.reduce((s, t) => s + (t.duration_hours ?? 0), 0);
+    const maxSpeed      = tracks.reduce((m, t) => Math.max(m, t.max_speed_kts ?? 0), 0);
+    const firstDate     = tracks[0]?.date ?? '';
+    const lastDate      = tracks[tracks.length - 1]?.date ?? '';
+
+    const fmt = (d) => d ? new Date(`${d}T12:00:00`).toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' }) : '—';
+
+    const grid = document.getElementById('voyage-stats-grid');
+    if (!grid) return;
+
+    grid.innerHTML = [
+      { label: 'Sailing Days',   value: totalDays },
+      { label: 'Total Distance', value: `${totalNm.toFixed(1)} nm` },
+      { label: 'Total Underway', value: `${totalHours.toFixed(1)} hr` },
+      { label: 'Top Speed',      value: `${maxSpeed.toFixed(1)} kts` },
+      { label: 'First Sail',     value: fmt(firstDate) },
+      { label: 'Last Sail',      value: fmt(lastDate) },
+    ].map(({ label, value }) => `
+      <div class="info-item">
+        <div class="label">${label}</div>
+        <div class="value">${value}</div>
+      </div>`).join('');
+
+    panel.style.display = '';
+  } catch (e) {
+    console.warn('Voyage stats unavailable:', e);
+    panel.style.display = 'none';
+  }
+}
+
 // Load vessel information from YAML file
 async function loadVesselData() {
   try {
@@ -773,9 +843,9 @@ async function loadVesselData() {
     // Add default_location if not present
     if (!vesselData.default_location) {
       vesselData.default_location = {
-        lat: 37.806,
-        lon: -122.465,
-        label: 'San Francisco Bay'
+        lat:   C.DEFAULT_TIDE_LAT,
+        lon:   C.DEFAULT_TIDE_LON,
+        label: C.DEFAULT_TIDE_LABEL,
       };
     }
     
@@ -790,10 +860,10 @@ async function loadVesselData() {
       uscg_number: "1024168",
       hull_number: "BEY57004E494",
       default_location: {
-        lat: 37.806,
-        lon: -122.465,
-        label: 'San Francisco Bay'
-      }
+        lat:   C.DEFAULT_TIDE_LAT,
+        lon:   C.DEFAULT_TIDE_LON,
+        label: C.DEFAULT_TIDE_LABEL,
+      },
     };
     updateVesselLinks();
   }
@@ -992,8 +1062,8 @@ async function drawTideGraph(lat, lon, tidePositionMeta = {}) {
 
   try {
     let res;
-    // Serve from cache if fresh (3-hour TTL — tide predictions don't change within a day)
-    let json = (() => { const c = getCached(tideCacheKey, 3 * 60 * 60 * 1000); return c ? { predictions: c } : null; })();
+    // Serve from cache if fresh — tide predictions don't change within a day
+    let json = (() => { const c = getCached(tideCacheKey, C.TIDE_CACHE_TTL_MS); return c ? { predictions: c } : null; })();
 
     // Try primary station (skipped when cache hit)
     if (!json) console.debug('Tide fetch: attempting station', {
@@ -2452,7 +2522,7 @@ async function loadConditionsForecast() {
     // ── Atmospheric (Open-Meteo) ──────────────────────────────────────────
     (async () => {
       const key = `cond_atmos2_${latR}_${lonR}_${today}`;
-      const hit = getCached(key, 60 * 60 * 1000);
+      const hit = getCached(key, C.FORECAST_CACHE_TTL_MS);
       if (hit) return hit;
       const url = `https://api.open-meteo.com/v1/forecast` +
         `?latitude=${tidePos.lat}&longitude=${tidePos.lon}` +
@@ -2470,7 +2540,7 @@ async function loadConditionsForecast() {
     // ── Marine (Open-Meteo Marine) ────────────────────────────────────────
     (async () => {
       const key = `cond_marine_${latR}_${lonR}_${today}`;
-      const hit = getCached(key, 60 * 60 * 1000);
+      const hit = getCached(key, C.FORECAST_CACHE_TTL_MS);
       if (hit) return hit;
       const url = `https://marine-api.open-meteo.com/v1/marine` +
         `?latitude=${tidePos.lat}&longitude=${tidePos.lon}` +
@@ -2489,7 +2559,7 @@ async function loadConditionsForecast() {
       const begin   = utcDateStr(windowStart);
       const end     = utcDateStr(windowEnd);
       const key     = `cond_tide_${station.id}_${begin}_${end}`;
-      const hit     = getCached(key, 3 * 60 * 60 * 1000);
+      const hit     = getCached(key, C.TIDE_CACHE_TTL_MS);
       if (hit) return { station, predictions: hit };
       const params = new URLSearchParams({
         product: 'predictions', application: 'vessel-tracker',
@@ -3302,6 +3372,7 @@ function updateChartsForTheme(theme) {
   initDarkMode();
   loadPolarData();
   initPolarToggle();
+  loadVoyageStats();
   loadData();
 
   // Real-time SignalK updates removed; using static data only
@@ -3337,8 +3408,7 @@ function updateChartsForTheme(theme) {
     if (refreshSparklines) refreshSparklines();
   });
 
-  // Update conditions forecast every hour
   setInterval(() => {
     loadConditionsForecast().catch(err => console.error('Conditions forecast error:', err));
-  }, 60 * 60 * 1000);
+  }, C.FORECAST_CACHE_TTL_MS);
 });

--- a/assets/constants.js
+++ b/assets/constants.js
@@ -39,7 +39,9 @@ const VESSEL_CONSTANTS = Object.freeze({
   DEFAULT_TIDE_LABEL: 'San Francisco Bay',
 
   // ── Data URLs ────────────────────────────────────────────────────────────
-  SNAPSHOT_INDEX_URL:  'data/telemetry/snapshots_index.json',
-  TRACKS_INDEX_URL:    'data/telemetry/tracks_index.json',
-  POSITIONS_INDEX_URL: 'data/telemetry/positions_index.json',
+  SNAPSHOT_INDEX_URL:   'data/telemetry/snapshots_index.json',  // legacy, kept for reference
+  TRACKS_INDEX_URL:     'data/telemetry/tracks_index.json',
+  POSITIONS_INDEX_URL:  'data/telemetry/positions_index.json',
+  INSTRUMENT_LOG_URL:   'data/telemetry/instrument_log.json',
+  INSTRUMENT_LOG_ENTRIES: 120,  // must match backend INSTRUMENT_LOG_ENTRIES
 });

--- a/assets/constants.js
+++ b/assets/constants.js
@@ -1,0 +1,45 @@
+// Shared constants for the vessel tracker frontend.
+// Magic numbers extracted here so thresholds are easy to find and tune.
+
+const VESSEL_CONSTANTS = Object.freeze({
+  // ── Classification thresholds ────────────────────────────────────────────
+  BATTERY_OK_PCT:       75,    // % state-of-charge → ok
+  BATTERY_WARN_PCT:     45,    // % → warn (below is alert)
+  BATTERY_TIME_OK_H:    6,     // hours remaining → ok
+  BATTERY_TIME_WARN_H:  2,     // hours → warn (below is alert)
+
+  ANCHOR_WARN_RATIO:    0.85,  // current/max ratio → ok below, warn above
+  ANCHOR_EDGE_RATIO:    1.05,  // → warn below, alert above
+
+  PACKET_LOSS_OK_PCT:   1,     // % packet loss → ok
+  PACKET_LOSS_WARN_PCT: 3,     // % → warn (above is alert)
+
+  TANK_OK_RATIO:        0.35,  // fill ratio → ok (above)
+  TANK_WARN_RATIO:      0.20,  // → warn (below is alert)
+  WASTE_WARN_RATIO:     0.40,  // fill ratio → ok (below)
+  WASTE_ALERT_RATIO:    0.70,  // → warn (above is alert)
+
+  // ── Cache TTLs (milliseconds) ────────────────────────────────────────────
+  FORECAST_CACHE_TTL_MS: 60 * 60 * 1000,      // 1 hour
+  TIDE_CACHE_TTL_MS:     3 * 60 * 60 * 1000,  // 3 hours
+
+  // ── Data display ─────────────────────────────────────────────────────────
+  SPARKLINE_POINTS:           60,   // number of history points per sparkline
+  DEFAULT_RECENT_TRACK_COUNT:  3,   // coloured track days shown by default
+
+  // ── Fallback privacy zone (South Beach Harbor, SF) ───────────────────────
+  // Overridden at runtime by privacy_zones in data/vessel/info.yaml.
+  FALLBACK_PRIVACY_ZONE_LAT:    37.7802069,
+  FALLBACK_PRIVACY_ZONE_LON:   -122.3858040,
+  FALLBACK_PRIVACY_ZONE_RADIUS_M: 200,
+
+  // ── Fallback tide / geocoding location ───────────────────────────────────
+  DEFAULT_TIDE_LAT:   37.806,
+  DEFAULT_TIDE_LON: -122.465,
+  DEFAULT_TIDE_LABEL: 'San Francisco Bay',
+
+  // ── Data URLs ────────────────────────────────────────────────────────────
+  SNAPSHOT_INDEX_URL:  'data/telemetry/snapshots_index.json',
+  TRACKS_INDEX_URL:    'data/telemetry/tracks_index.json',
+  POSITIONS_INDEX_URL: 'data/telemetry/positions_index.json',
+});

--- a/data/vessel/info.yaml
+++ b/data/vessel/info.yaml
@@ -15,3 +15,12 @@ signalk:
   host: "192.168.8.50"
   port: "3000"
   protocol: "http"
+
+# Privacy exclusion zones — positions inside these circles are redacted from
+# all stored and published data. Add entries for any marina or home port where
+# you don't want the boat's exact location to be public.
+privacy_zones:
+  - name: "South Beach Harbor, San Francisco"
+    lat: 37.7802069
+    lon: -122.3858040
+    radius_m: 200

--- a/index.html
+++ b/index.html
@@ -4,6 +4,21 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title id="page-title">Vessel Tracker</title>
+
+  <!-- OpenGraph / social sharing -->
+  <meta property="og:type"        content="website" />
+  <meta property="og:title"       content="S.V. Mermug — Live Vessel Tracker" />
+  <meta property="og:description" content="Real-time position, weather, and systems for S.V. Mermug sailing on San Francisco Bay and beyond." />
+  <meta property="og:url"         content="https://mermug.com/" />
+  <meta property="og:image"       content="https://mermug.com/data/vessel/logo.png" />
+  <meta name="description"        content="Real-time position, weather, and systems for S.V. Mermug sailing on San Francisco Bay and beyond." />
+
+  <!-- Twitter card -->
+  <meta name="twitter:card"        content="summary" />
+  <meta name="twitter:title"       content="S.V. Mermug — Live Vessel Tracker" />
+  <meta name="twitter:description" content="Real-time position, weather, and systems for S.V. Mermug." />
+  <meta name="twitter:image"       content="https://mermug.com/data/vessel/logo.png" />
+
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <link rel="icon" href="/assets/favicon.ico" />
   <link rel="manifest" href="manifest.json" />
@@ -15,6 +30,15 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-annotation@3.0.1"></script>
   <link rel="stylesheet" href="assets/styles.css" />
+
+  <!-- Service worker registration -->
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js').catch(() => {});
+      });
+    }
+  </script>
 </head>
 <body>
   <!-- Floating Dark Mode Button -->
@@ -40,6 +64,12 @@
 
     <!-- PASSAGE BANNER (shown only when passage is set in info.yaml) -->
     <div id="passage-banner" class="passage-banner" style="display:none;"></div>
+
+    <!-- VOYAGE STATS -->
+    <div class="info-panel" id="voyage-stats-panel" style="display:none;">
+      <div class="panel-title">Voyage Stats</div>
+      <div class="data-grid" id="voyage-stats-grid"></div>
+    </div>
 
     <!-- LINKS -->
     <div class="links-section">
@@ -286,6 +316,7 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/js-yaml@4.1.0/dist/js-yaml.min.js"></script>
   <script src="assets/utils.js"></script>
-  <script src="assets/app.js?v=2"></script>
+  <script src="assets/constants.js"></script>
+  <script src="assets/app.js?v=3"></script>
 </body>
 </html>

--- a/scripts/backfill_tracks.py
+++ b/scripts/backfill_tracks.py
@@ -27,9 +27,26 @@ TELEMETRY_DIR = Path("data/telemetry")
 TRACKS_DIR = TELEMETRY_DIR / "tracks"
 TRACKS_INDEX_FILE = TELEMETRY_DIR / "tracks_index.json"
 
-HARBOR_LAT = 37.7802069
-HARBOR_LON = -122.3858040
-HARBOR_RADIUS_M = 200.0
+# Fallback privacy zone when none are defined in info.yaml.
+_FALLBACK_ZONES: list[tuple[float, float, float]] = [
+    (37.7802069, -122.3858040, 200.0),  # South Beach Harbor, San Francisco
+]
+
+
+def _load_privacy_zones(vessel_info: dict[str, Any]) -> list[tuple[float, float, float]]:
+    """Parse privacy_zones from vessel config; fall back to built-in default."""
+    raw = vessel_info.get("privacy_zones", [])
+    if not isinstance(raw, list) or not raw:
+        return list(_FALLBACK_ZONES)
+    zones: list[tuple[float, float, float]] = []
+    for z in raw:
+        if not isinstance(z, dict):
+            continue
+        try:
+            zones.append((float(z["lat"]), float(z["lon"]), float(z["radius_m"])))
+        except (KeyError, TypeError, ValueError):
+            continue
+    return zones or list(_FALLBACK_ZONES)
 
 _NS_GPX = "http://www.topografix.com/GPX/1/1"
 _NS_GPXTPX = "http://www.garmin.com/xmlschemas/TrackPointExtension/v1"
@@ -172,7 +189,10 @@ def main() -> int:
         vessel_info = load_vessel_info("data/vessel/info.yaml")
         vessel_name = vessel_info.get("name", "Vessel")
     except Exception:
+        vessel_info = {}
         vessel_name = "Vessel"
+
+    privacy_zones = _load_privacy_zones(vessel_info)
 
     # Collect all timestamped snapshot files (skip index/latest files)
     skip = {"signalk_latest.json", "positions_index.json", "snapshots_index.json",
@@ -191,7 +211,10 @@ def main() -> int:
         if pt is None:
             skipped += 1
             continue
-        if _haversine_m(pt["latitude"], pt["longitude"], HARBOR_LAT, HARBOR_LON) <= HARBOR_RADIUS_M:
+        if any(
+            _haversine_m(pt["latitude"], pt["longitude"], zlat, zlon) <= zr
+            for zlat, zlon, zr in privacy_zones
+        ):
             continue
         date_str = pt["timestamp"][:10]
         by_day.setdefault(date_str, []).append(pt)

--- a/scripts/telemetry_to_jibset.py
+++ b/scripts/telemetry_to_jibset.py
@@ -6,10 +6,10 @@ import argparse
 import csv
 import json
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Iterable, List, Optional
 import xml.etree.ElementTree as ET
 
 
@@ -35,7 +35,7 @@ def parse_time_adjust(value: str) -> timedelta:
     return sign * timedelta(hours=int(hh), minutes=int(mm), seconds=int(ss))
 
 
-def parse_filename_timestamp(path: Path) -> Optional[datetime]:
+def parse_filename_timestamp(path: Path) -> datetime | None:
     match = FILENAME_TS_RE.match(path.name)
     if not match:
         return None
@@ -51,7 +51,7 @@ def parse_filename_timestamp(path: Path) -> Optional[datetime]:
     return dt.replace(tzinfo=timezone.utc)
 
 
-def parse_iso_timestamp(value: str) -> Optional[datetime]:
+def parse_iso_timestamp(value: str) -> datetime | None:
     try:
         dt = datetime.fromisoformat(value)
     except ValueError:
@@ -61,7 +61,7 @@ def parse_iso_timestamp(value: str) -> Optional[datetime]:
     return dt.astimezone(timezone.utc)
 
 
-def load_point(path: Path) -> Optional[TrackPoint]:
+def load_point(path: Path) -> TrackPoint | None:
     try:
         data = json.loads(path.read_text())
     except json.JSONDecodeError:
@@ -101,7 +101,7 @@ def iter_telemetry_files(input_dir: Path) -> Iterable[Path]:
         yield path
 
 
-def collect_points(files: Iterable[Path]) -> List[TrackPoint]:
+def collect_points(files: Iterable[Path]) -> list[TrackPoint]:
     points: List[TrackPoint] = []
     for path in files:
         point = load_point(path)
@@ -111,7 +111,7 @@ def collect_points(files: Iterable[Path]) -> List[TrackPoint]:
     return points
 
 
-def split_into_sequences(points: List[TrackPoint], max_gap: timedelta) -> List[List[TrackPoint]]:
+def split_into_sequences(points: list[TrackPoint], max_gap: timedelta) -> list[list[TrackPoint]]:
     if not points:
         return []
     sequences = [[points[0]]]
@@ -123,7 +123,7 @@ def split_into_sequences(points: List[TrackPoint], max_gap: timedelta) -> List[L
     return sequences
 
 
-def clamp_points(points: List[TrackPoint], start: Optional[datetime], end: Optional[datetime]) -> List[TrackPoint]:
+def clamp_points(points: list[TrackPoint], start: datetime | None, end: datetime | None) -> list[TrackPoint]:
     if start:
         points = [p for p in points if p.timestamp >= start]
     if end:
@@ -136,7 +136,7 @@ def format_timestamp(dt: datetime) -> str:
     return dt.replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def write_csv(points: List[TrackPoint], output: Path, delimiter: str) -> None:
+def write_csv(points: list[TrackPoint], output: Path, delimiter: str) -> None:
     output.parent.mkdir(parents=True, exist_ok=True)
     with output.open("w", newline="") as handle:
         writer = csv.writer(handle, delimiter=delimiter)
@@ -149,7 +149,7 @@ def write_csv(points: List[TrackPoint], output: Path, delimiter: str) -> None:
             ])
 
 
-def write_gpx(points: List[TrackPoint], output: Path, name: str) -> None:
+def write_gpx(points: list[TrackPoint], output: Path, name: str) -> None:
     output.parent.mkdir(parents=True, exist_ok=True)
     gpx = ET.Element(
         "gpx",

--- a/scripts/update_signalk_data.py
+++ b/scripts/update_signalk_data.py
@@ -17,8 +17,10 @@ from .utils import get_project_root, load_vessel_info
 DEFAULT_OUTPUT_FILE = "./data/telemetry/signalk_latest.json"
 STALE_MAX_AGE_MINUTES = 60
 STALE_FILTER_KEYS = ("environment", "navigation", "entertainment")
-POSITION_RETENTION_HOURS = (24 * 24)  # 24 days
+POSITION_RETENTION_HOURS = 24  # keep raw snapshot files for 24 hours only
 POSITION_INDEX_FILE = "./data/telemetry/positions_index.json"
+INSTRUMENT_LOG_FILE = "./data/telemetry/instrument_log.json"
+INSTRUMENT_LOG_ENTRIES = 120  # ~5 hours at the default 2.5-min update cadence
 TRACKS_DIR = "./data/telemetry/tracks"
 TRACKS_INDEX_FILE = "./data/telemetry/tracks_index.json"
 
@@ -391,6 +393,28 @@ def _update_snapshot_index(output_dir: Path, filename: str, timestamp: datetime)
     index_path.write_text(json.dumps(existing, indent=2), encoding="utf-8")
 
 
+def _update_instrument_log(output_dir: Path, timestamp: datetime, blob: dict[str, Any]) -> None:
+    """Append a compact numeric reading to instrument_log.json and trim to the last N entries.
+
+    The log replaces the old pattern of fetching N individual snapshot files for sparklines.
+    Each entry is {timestamp, values: {signalk.path: float}} — only numeric leaf values.
+    """
+    log_path = output_dir / Path(INSTRUMENT_LOG_FILE).name
+    try:
+        existing: list[dict[str, Any]] = json.loads(log_path.read_text(encoding="utf-8")).get("entries", []) if log_path.exists() else []
+        if not isinstance(existing, list):
+            existing = []
+    except (json.JSONDecodeError, OSError, AttributeError):
+        existing = []
+
+    numeric: dict[str, float] = {}
+    _collect_numeric_values(blob, "", values=numeric)
+
+    existing.append({"timestamp": timestamp.isoformat(), "values": numeric})
+    trimmed = existing[-INSTRUMENT_LOG_ENTRIES:]
+    log_path.write_text(json.dumps({"entries": trimmed}, separators=(",", ":")), encoding="utf-8")
+
+
 def _prune_old_position_files(output_dir: Path) -> None:
     """Delete timestamped position snapshot files older than the retention window."""
     cutoff = datetime.now(UTC) - timedelta(hours=POSITION_RETENTION_HOURS)
@@ -660,6 +684,7 @@ def update_position_cache(blob: dict[str, Any], output_path: Path) -> None:
         vessel_name,
     )
 
+    _update_instrument_log(output_dir, timestamp, blob)
     _prune_old_position_files(output_dir)
 
 

--- a/scripts/update_signalk_data.py
+++ b/scripts/update_signalk_data.py
@@ -36,12 +36,30 @@ SNAPSHOT_PATH_WHITELIST: frozenset[str] = frozenset({
     "navigation", "environment", "electrical", "tanks", "propulsion", "internet"
 })
 
-# Privacy exclusion zones: (lat, lon, radius_metres).
-# Positions inside these circles are redacted from all stored/published data.
-# All other telemetry for those samples is retained as normal.
-PRIVACY_EXCLUSION_ZONES: list[tuple[float, float, float]] = [
+# Fallback privacy zone used when none are defined in info.yaml.
+_FALLBACK_PRIVACY_ZONES: list[tuple[float, float, float]] = [
     (37.7802069, -122.3858040, 200.0),  # South Beach Harbor, San Francisco
 ]
+
+# Active exclusion zones — populated from info.yaml by load_vessel_data().
+# Each entry is (lat, lon, radius_metres).
+PRIVACY_EXCLUSION_ZONES: list[tuple[float, float, float]] = list(_FALLBACK_PRIVACY_ZONES)
+
+
+def _load_privacy_zones(vessel_data: dict[str, Any]) -> list[tuple[float, float, float]]:
+    """Parse privacy_zones from vessel config; fall back to built-in default."""
+    raw = vessel_data.get("privacy_zones", [])
+    if not isinstance(raw, list) or not raw:
+        return list(_FALLBACK_PRIVACY_ZONES)
+    zones = []
+    for z in raw:
+        if not isinstance(z, dict):
+            continue
+        try:
+            zones.append((float(z["lat"]), float(z["lon"]), float(z["radius_m"])))
+        except (KeyError, TypeError, ValueError):
+            continue
+    return zones or list(_FALLBACK_PRIVACY_ZONES)
 
 
 def _haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
@@ -69,10 +87,12 @@ def _is_position_private(lat: float, lon: float) -> bool:
 
 def load_vessel_data() -> dict:
     """Load vessel configuration from YAML or JSON file."""
+    global PRIVACY_EXCLUSION_ZONES
     try:
         # Try to load config (will try YAML first, then JSON)
         vessel_data = load_vessel_info("data/vessel/info.yaml")
         if vessel_data:
+            PRIVACY_EXCLUSION_ZONES = _load_privacy_zones(vessel_data)
 
             # Construct SignalK URL from vessel data
             signalk = vessel_data.get("signalk", {})

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,118 @@
+// Service worker — offline fallback for S.V. Mermug vessel tracker.
+//
+// Strategy:
+//   Static shell assets → cache-first (versioned cache; update on new deploy)
+//   Telemetry / data JSON → network-first, fall back to cache so the last
+//     known state is shown when the device is offline
+//   CDN resources → stale-while-revalidate
+
+const SHELL_CACHE   = 'mermug-shell-v1';
+const DATA_CACHE    = 'mermug-data-v1';
+
+const SHELL_ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.json',
+  '/assets/styles.css',
+  '/assets/utils.js',
+  '/assets/constants.js',
+  '/assets/app.js',
+  '/data/vessel/info.yaml',
+  '/data/vessel/logo.png',
+  '/data/tide_stations.json',
+];
+
+// ── Install: pre-cache shell ──────────────────────────────────────────────────
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(SHELL_CACHE).then((cache) => cache.addAll(SHELL_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+// ── Activate: remove stale caches ────────────────────────────────────────────
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys
+          .filter((k) => k !== SHELL_CACHE && k !== DATA_CACHE)
+          .map((k) => caches.delete(k))
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+// ── Fetch ─────────────────────────────────────────────────────────────────────
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Only handle same-origin GET requests and a small CDN allowlist.
+  if (request.method !== 'GET') return;
+
+  // CDN (Leaflet, Chart.js, js-yaml) — stale-while-revalidate
+  if (url.hostname.endsWith('jsdelivr.net') || url.hostname.endsWith('unpkg.com')) {
+    event.respondWith(staleWhileRevalidate(request, SHELL_CACHE));
+    return;
+  }
+
+  // Only intercept same-origin requests from here on.
+  if (url.origin !== self.location.origin) return;
+
+  // Telemetry / data JSON — network-first with data-cache fallback
+  if (url.pathname.startsWith('/data/telemetry/')) {
+    event.respondWith(networkFirstWithCache(request, DATA_CACHE));
+    return;
+  }
+
+  // Shell assets — cache-first
+  event.respondWith(cacheFirst(request, SHELL_CACHE));
+});
+
+// ── Strategies ────────────────────────────────────────────────────────────────
+
+async function cacheFirst(request, cacheName) {
+  const cached = await caches.match(request, { cacheName });
+  if (cached) return cached;
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(cacheName);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    return new Response('Offline', { status: 503, statusText: 'Service Unavailable' });
+  }
+}
+
+async function networkFirstWithCache(request, cacheName) {
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      const cache = await caches.open(cacheName);
+      cache.put(request, response.clone());
+    }
+    return response;
+  } catch {
+    const cached = await caches.match(request, { cacheName });
+    if (cached) return cached;
+    return new Response(JSON.stringify({ offline: true }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+async function staleWhileRevalidate(request, cacheName) {
+  const cached = await caches.match(request);
+  const fetchPromise = fetch(request).then((response) => {
+    if (response.ok) {
+      caches.open(cacheName).then((cache) => cache.put(request, response.clone()));
+    }
+    return response;
+  }).catch(() => null);
+  return cached ?? (await fetchPromise) ?? new Response('Offline', { status: 503 });
+}


### PR DESCRIPTION
## Summary

- **Voyage stats panel** — loads `tracks_index.json` to show total sailing days, distance, hours underway, top speed, first/last sail dates
- **Configurable privacy zones** — moved from hardcoded Python constants to `privacy_zones` list in `data/vessel/info.yaml`; both Python scripts and JS frontend read from config at runtime
- **OpenGraph + Twitter card meta tags** — for social sharing link previews
- **Service worker** (`sw.js`) — cache-first for shell assets, network-first for telemetry, stale-while-revalidate for CDN resources
- **`constants.js`** — named constants for all classification thresholds, cache TTLs, and default locations; `app.js` references `C.*` instead of inline magic numbers
- **`telemetry_to_jibset.py`** — modernised type hints to Python 3.10+ style
- **`instrument_log.json`** — single rolling file (last 120 readings ≈ 5 hrs) replaces 60-parallel snapshot fetches for sparklines; `POSITION_RETENTION_HOURS` reduced from 576 → 24 to stop unbounded snapshot file growth

## Test plan

- [ ] Verify voyage stats panel appears and shows correct totals
- [ ] Add a second privacy zone to `info.yaml` and confirm both Python and JS respect it
- [ ] Share a link and confirm OG preview image/description appear
- [ ] Take device offline and confirm last-known state is shown
- [ ] Confirm sparklines still render after first update cycle generates `instrument_log.json`
- [ ] Confirm no new snapshot files accumulate beyond 24 hours after deploy