### PR TITLE
Fix tracks not showing when all recent positions are in privacy zone

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -534,8 +534,6 @@ async function loadTrack() {
         && Number.isFinite(p.longitude)
         && !isInPrivacyZone(p.latitude, p.longitude));
 
-    if (!positions.length) return;
-
     // Group by LOCAL calendar day (YYYY-MM-DD) so one day's track is one color.
     const byDay = new Map();
     for (const p of positions) {
@@ -549,8 +547,9 @@ async function loadTrack() {
     }
 
     trackByDay = byDay;
-    renderTracks();
+    if (positions.length) renderTracks();
     // Load historical tracks (GPX files) without blocking the initial render.
+    // Always runs even when all recent positions are in a privacy zone.
     loadHistoricalTracks();
   } catch (error) {
     console.warn('Unable to load track data:', error);


### PR DESCRIPTION
When the boat is at anchor in the marina, all positions in positions_index.json
fall within the privacy exclusion zone and are filtered out. The early return on
empty positions prevented loadHistoricalTracks() from ever being called, so no
GPX track history was displayed. Now historical tracks always load regardless of
whether recent positions are visible.

https://claude.ai/code/session_011gxKMjtXqoxEJrgg7BboEV