### PR TITLE
Add boat documentation under docs/

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,84 @@
+# S.V. Mermug — Vessel Changelog
+
+Running log of modifications, repairs, upgrades, and significant maintenance events.
+
+Format: `YYYY-MM-DD | Category | Description`
+
+Categories: **Electronics** | **Engine** | **Rigging** | **Sails** | **Electrical** | **Plumbing** | **Safety** | **Hull/Deck** | **Software** | **Other**
+
+---
+
+## 2025
+
+### 2025-05-XX | Electronics | Vessel tracker deployed
+- Launched [mermug.com](https://mermug.com) — Raspberry Pi aboard running SignalK → GitHub Pages pipeline.
+- SignalK server running on `192.168.8.50:3000`.
+- Data update cadence: ~150 seconds.
+- Privacy zone configured for South Beach Harbor (200 m radius).
+
+<!-- Add entries above this line, newest first -->
+
+---
+
+## 2024
+
+<!-- Add 2024 entries here -->
+
+---
+
+## 2023
+
+<!-- Add 2023 entries here -->
+
+---
+
+## Recurring Maintenance Schedule
+
+Reference table for planned maintenance intervals. Update "Last Done" column after each service.
+
+| Item | Interval | Last Done | Notes |
+|------|----------|-----------|-------|
+| Engine oil & filter | 100 hrs or annually | — | |
+| Raw water impeller | Annually (spring) | — | Carry spare aboard |
+| Transmission fluid | 2 years | — | |
+| Fuel filter (primary) | Annually | — | |
+| Fuel filter (Racor) | 200 hrs or annually | — | |
+| Coolant flush | 2 years | — | |
+| Engine zincs | Annually | — | |
+| Drive belt(s) | Inspect annually / replace as needed | — | Carry spare |
+| Standing rigging inspection | Annually | — | Check for meat hooks, broken strands, corrosion |
+| Running rigging inspection | Annually | — | Sheaves, blocks, clutches, halyards |
+| Sail inspection | Annually | — | Stitching, UV cover, batten pockets |
+| Lifeline & stanchion inspection | Annually | — | Swage integrity, stanchion bases |
+| Seacocks — cycle and grease | Annually | — | |
+| Through-hull inspection | Haulout | — | |
+| Bottom paint | Annually (spring haulout) | — | |
+| Hull zinc replacement | Haulout | — | |
+| Prop & shaft inspection | Haulout | — | Check zinc, look for fishing line |
+| Fire extinguisher service | 6 years (hydrotest 12 yr) | — | |
+| EPIRB registration & battery | Per label / 5 years | — | |
+| Flare expiration | Check annually | — | 3-yr shelf life |
+| Life jacket inspection | Annually | — | Inflate manual PFDs; check auto-inflate |
+| Bilge pump test | Monthly | — | |
+| Engine raw water strainer | Monthly or as needed | — | |
+
+---
+
+## Parts & Specs Reference
+
+Useful cross-references for ordering parts.
+
+| Component | Make/Model | Part # | Notes |
+|-----------|-----------|--------|-------|
+| Engine | — | — | |
+| Raw water impeller | — | — | |
+| Primary fuel filter | — | — | |
+| Racor filter element | — | — | |
+| Engine oil spec | — | — | |
+| Drive belt | — | — | |
+| Anchor windlass | — | — | |
+| VHF radio | — | — | |
+| Chartplotter | — | — | |
+| AIS transponder | — | — | |
+| Battery bank | — | — | |
+| Battery charger | — | — | |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,224 @@
+# S.V. Mermug — Operations Guide
+
+42.7-ft sloop, Hull #BEY57004E494 | MMSI 338543654 | USCG 1024168  
+Home berth: South Beach Harbor, San Francisco
+
+---
+
+## Pre-Departure Checklist
+
+### Safety & Documentation
+- [ ] Ship's papers aboard (documentation, registration, insurance)
+- [ ] Float plan filed with a shore contact
+- [ ] Flares in date (check expiration on handheld and parachute flares)
+- [ ] Life jackets accessible and in good condition (one per person + throwable)
+- [ ] EPIRB registered, battery in date, hydrostatic release in date
+- [ ] First aid kit stocked
+- [ ] Fire extinguishers charged and accessible
+
+### Engine
+- [ ] Engine oil level — check dipstick, should be between min/max
+- [ ] Raw water strainer clear
+- [ ] Coolant level in overflow reservoir
+- [ ] Belt tension — alternator and raw water pump belts
+- [ ] Fuel level — check gauge and visually at fill deck plate
+- [ ] Transmission fluid level
+- [ ] No unusual odors in engine compartment (fuel, burning)
+
+### Electrical
+- [ ] House battery state of charge — aim for ≥80% before departure
+- [ ] Start battery isolated from house bank
+- [ ] Nav lights functional (steaming, port, starboard, stern, anchor)
+- [ ] VHF radio on and scanning Ch 16
+- [ ] AIS transmitting (verify on chartplotter)
+- [ ] Chartplotter + instruments powered and GPS locked
+
+### Rigging & Deck
+- [ ] Running rigging led properly; halyards, sheets, guys cleated or coiled
+- [ ] Standing rigging — quick visual on turnbuckles, cotter pins, stays
+- [ ] Boom vang, cunningham, outhaul: tension set for conditions
+- [ ] Furling systems: headsail and main furled cleanly, lines free to run
+- [ ] Hatches dogged shut (or confirmed open intentionally)
+- [ ] Through-hulls checked — know which are open, which closed
+- [ ] Bilge pumps operational; bilge dry or at normal level
+
+### Navigation
+- [ ] Charts loaded / paper chart aboard for the area
+- [ ] Tide and current reviewed for departure, transit, arrival
+- [ ] Weather briefed — NOAA, PredictWind, or Passage Weather
+- [ ] Waypoints entered in chartplotter if applicable
+- [ ] Hazards noted (shipping lanes, rocks, TSS boundaries)
+
+---
+
+## Engine Start Procedure
+
+1. Open raw water seacock (under companion way steps, starboard side).
+2. Turn ignition key to **ON** — gauges come alive, blower runs for 30 sec.
+3. Confirm fuel is on (main valve at tank, should always be open).
+4. Shift to neutral if not already.
+5. Turn key to **START** — do not crank more than 10 seconds at a stretch.
+6. Once running: confirm raw water exhaust flowing at transom (within ~20 sec).
+7. Let engine warm at ~1000 RPM for 2–3 minutes before putting in gear.
+8. Confirm oil pressure in normal range on gauge.
+
+> If raw water flow does not appear within 30 seconds of startup, shut down immediately and check the strainer and seacock.
+
+---
+
+## Leaving the Slip
+
+### South Beach Harbor (Home Berth)
+
+- Slip is **[slip number TBD]**, pier **[pier TBD]**.
+- Prevailing wind is W–SW; boat will weathervane bow into the wind when lines ease.
+- Spring lines: forward spring cleats to mid-cleat on dock; aft spring to stern cleat.
+- Standard procedure when departing single-handed into a westerly:
+  1. Remove all lines except the forward spring.
+  2. Back down on the spring — boat swings bow out.
+  3. When clear, remove spring, shift to forward, depart.
+
+### General Slip Departure
+1. Fenders deployed until clear of dock; assign someone to tend fenders.
+2. Assign roles: helm, bow line, stern line, spring.
+3. Call out "lines off" order (usually stern → bow → springs or use springs to swing).
+4. Motor out at idle until clear of the marina fairway.
+5. Stow dock lines and fenders before leaving the fairway.
+
+---
+
+## Sail Handling
+
+### Hoisting the Mainsail
+1. Ease mainsheet fully; boom traveler to centerline.
+2. Ease vang to zero.
+3. Head into the wind (or motor head-to-wind if in tight quarters).
+4. Remove sail cover; remove boom crutch if deployed.
+5. Release reefing lines fully.
+6. Hoist main halyard — hand-over-hand to luff, then winch to proper tension.
+7. Ease cunningham and outhaul to shape for conditions.
+8. Cleat halyard on mast cleat and coil tail.
+
+### Furling the Headsail
+- Sheet in slightly before furling — keeps sail from flogging and wrapping evenly.
+- Furl from the cockpit using the furling line — steady even tension.
+- Lock off furling drum when furled; coil furling line.
+
+### Reefing the Main
+
+**First Reef:**
+1. Ease mainsheet to depower.
+2. Drop main halyard until reefing cringle (luff) meets the boom.
+3. Hook luff cringle onto reefing hook at gooseneck.
+4. Re-tension halyard.
+5. Pull aft reefing line (reef 1) until leech cringle is snug at boom.
+6. Cleat and coil. Tie reef points loosely if desired.
+
+**Second Reef:** same procedure using the second set of cringles and reef line.
+
+> Rule of thumb: if you're thinking about reefing, reef.
+
+---
+
+## Anchoring
+
+### Gear
+- Primary: **35 lb Delta** on **200 ft 5/16" chain** + **150 ft 5/8" nylon rode**
+- Secondary: **[secondary anchor TBD]**
+- Windlass: **[windlass model TBD]**, foot switches at bow, breaker at nav station
+
+### Procedure
+1. Select anchorage — check chart for depth, swinging room, bottom type (sand/mud preferred).
+2. Motor slowly upwind/upcurrent of desired spot.
+3. Depth at target + 1 ft of water + rode scope. Use 5:1 scope minimum; 7:1 in wind.
+4. Stop headway; lower anchor slowly by windlass until it touches bottom.
+5. Back down slowly on engine — pay out scope as boat falls back.
+6. Set with a brief burst of reverse (1500–2000 RPM) until rode goes taut.
+7. Take two bearings 90° apart; log them in the chartplotter or notebook.
+8. Let out snubber: 20–30 ft of line from bow cleat to chain with snatch hook — takes load off windlass.
+9. Mark position on chartplotter; set anchor drag alarm.
+
+### Retrieving the Anchor
+1. Motor slowly to short scope; windlass retrieves as boat moves forward.
+2. When anchor breaks free, signal helmsman ("anchor aweigh").
+3. Rinse chain/anchor with deck wash as it comes aboard.
+4. Secure anchor with safety pin; stow snubber.
+
+---
+
+## Returning to Slip
+
+1. Radio the marina on **[marina channel TBD]** if required.
+2. Reduce speed to bare steerage in the harbor — no wake.
+3. Assign bow, stern, and spring line handlers before entering the fairway.
+4. Approach slip slowly, into the wind if possible.
+5. Lead lines to dock cleats; spring the boat in if needed.
+6. Shut down engine: key to OFF; close raw water seacock.
+7. Connect shore power; confirm charging light on battery monitor.
+8. Log hours on the engine hour meter.
+
+---
+
+## Post-Arrival / Layup
+
+- [ ] Engine hours logged
+- [ ] Sail covers on (main first, then headsail)
+- [ ] Boom crutch deployed; mainsheet eased
+- [ ] Halyards flaked or secured to prevent slapping (use sail ties or slight tension to shroud)
+- [ ] Shore power connected; battery charger on
+- [ ] Seacocks closed (raw water, head, any open thru-hulls)
+- [ ] Bilge checked — pump if any accumulation
+- [ ] Docklines doubled / snugged for conditions
+- [ ] Instruments and electronics powered down
+- [ ] Companionway locked
+
+---
+
+## Emergency Procedures
+
+### Man Overboard (MOB)
+1. **Shout "Man overboard!"** — designate a spotter; do not take your eyes off the person.
+2. **Press MOB button** on chartplotter immediately.
+3. Throw the horseshoe buoy and/or any floating object.
+4. **Quick-stop maneuver**: tack immediately without releasing sheets → heave to → return on a reach.
+5. Approach MOB from downwind; stop with them at the beam, windward side.
+6. Deploy boarding ladder or use spinnaker halyard + bosun's chair to recover.
+7. Call **USCG Ch 16 — MAYDAY** if recovery is delayed.
+
+### Engine Failure
+1. Raise sails immediately if not already up.
+2. Call marina or USCG on Ch 16 — "Pan-Pan" if urgency, "Mayday" if grave danger.
+3. Anchor if approaching a hazard.
+4. Diagnose: fuel, overheating, raw water, belt failure.
+
+### Fire
+1. **Engine compartment**: shut off fuel at tank, CO₂ extinguisher through the inspection port — do **not** open the hatch.
+2. **Cabin**: evacuate, deploy extinguisher, prepare to abandon ship if needed.
+3. **Mayday on Ch 16** — give position, vessel description, nature of emergency, souls aboard.
+
+### Taking on Water
+1. Locate source immediately.
+2. Deploy bilge pump (electric + manual).
+3. Plug with rags, softwood plugs, seacock plug if a through-hull failure.
+4. If uncontrolled: call Mayday; prepare life raft and ditch bag.
+
+---
+
+## Radio Communications
+
+- **Hailing and distress**: Ch 16 (always monitor)
+- **Working channel (SF Bay)**: Ch 68 or 69 for vessel-to-vessel
+- **USCG SF Traffic**: Ch 14
+- **Bridge openings**: varies — consult chart or call on Ch 16
+
+### Mayday Call Format
+```
+MAYDAY MAYDAY MAYDAY
+This is [vessel name] [vessel name] [vessel name]
+MMSI [number]
+We are [nature of distress]
+Our position is [lat/lon or bearing/distance from landmark]
+We have [number] persons aboard
+[Any other relevant information]
+MAYDAY [vessel name] over
+```

--- a/docs/systems.md
+++ b/docs/systems.md
@@ -1,0 +1,388 @@
+# S.V. Mermug — Systems Overview
+
+42.7-ft sloop, Hull #BEY57004E494  
+This document describes the major onboard systems: what's installed, where it is, how it works, and what to watch out for.
+
+---
+
+## Table of Contents
+
+1. [Hull & Rig](#1-hull--rig)
+2. [Engine & Drive](#2-engine--drive)
+3. [Fuel System](#3-fuel-system)
+4. [Electrical System](#4-electrical-system)
+5. [Plumbing & Freshwater](#5-plumbing--freshwater)
+6. [Navigation & Electronics](#6-navigation--electronics)
+7. [Safety Equipment](#7-safety-equipment)
+8. [Ground Tackle](#8-ground-tackle)
+9. [Sails & Running Rigging](#9-sails--running-rigging)
+10. [Vessel Data / Automation](#10-vessel-data--automation)
+
+---
+
+## 1. Hull & Rig
+
+| Spec | Value |
+|------|-------|
+| LOA | 42.7 ft |
+| Beam | 13.9 ft |
+| Draft | 6.2 ft |
+| Displacement | — |
+| Ballast | — |
+| Rig type | Sloop (masthead / fractional — confirm) |
+| Mast material | Aluminum |
+| Boom | — |
+
+### Standing Rigging
+- **Forestay**: [wire / rod] — [size]
+- **Backstay**: [wire / rod] — adjustable? [yes/no]
+- **Upper shrouds**: [size / chainplate location]
+- **Lower shrouds**: [fore lowers, aft lowers]
+- **Babystay / inner forestay**: [installed? yes/no]
+
+### Last Rig Inspection
+Date: —  
+Inspector: —  
+Notes: —
+
+---
+
+## 2. Engine & Drive
+
+| Spec | Value |
+|------|-------|
+| Make/Model | — |
+| Year | — |
+| HP | — |
+| Cylinders | — |
+| Fuel | Diesel |
+| Hours (as of last log) | — |
+| Raw water pump impeller | — |
+| Oil spec | — |
+| Oil capacity | — |
+| Coolant type | — |
+| Drive | Shaft drive |
+| Transmission | — |
+| Propeller | [folding / feathering / fixed], [diameter × pitch] |
+| Shaft zinc | Replace at haulout |
+
+### Engine Location
+Accessed via companionway steps (lift steps) and engine compartment panels. Raw water seacock is [location]. Bleed screws are [location].
+
+### Starting & Stopping
+See [Operations Guide — Engine Start Procedure](operations.md#engine-start-procedure).
+
+### Raw Water Cooling Circuit
+Raw water enters via seacock → strainer (starboard, under steps) → impeller pump → heat exchanger → exhaust mixing elbow → out transom. **Check exhaust flow within 30 seconds of start.**
+
+### Engine Alarms
+- **High temp**: [alarm sound / light — describe]
+- **Low oil pressure**: [describe]
+- **Alternator fault**: [describe]
+
+---
+
+## 3. Fuel System
+
+| Spec | Value |
+|------|-------|
+| Tank capacity | — gallons |
+| Tank material | [aluminum / poly / fiberglass] |
+| Tank location | Under [salon sole / quarter berth] |
+| Fuel type | Diesel |
+| Primary filter | [location] |
+| Racor (secondary filter) | [location] |
+| Fill deck plate | [port / starboard / both] |
+
+### Fuel Gauge
+Located at [nav station / helm]. Accuracy: [note if gauge is unreliable — e.g., only accurate when heeled < X°].
+
+### Bleeding the Engine
+If air enters the fuel system (e.g., ran tank dry):
+1. [Describe bleed procedure for this specific engine]
+2. Bleed Racor first — open bowl petcock, pump primer until fuel flows.
+3. Bleed injection pump at [location].
+
+### Fuel Management
+- Fill before offshore passages; diesel stores well.
+- Treat with biocide if boat sits unused for extended periods.
+- Log fuel additions in the [engine hours log / ship's log].
+
+---
+
+## 4. Electrical System
+
+### Battery Bank
+
+| Bank | Type | Capacity | Location |
+|------|------|----------|----------|
+| House bank | [AGM / lithium / flooded] | — Ah | [location] |
+| Start battery | [type] | — Ah | [location] |
+
+### Battery Monitor
+- **Make/Model**: [e.g., Victron BMV-712]
+- **Location**: Nav station / helm
+- Monitors house bank state of charge, voltage, current draw, and time-to-empty.
+- SignalK reports SOC and draw — visible on [mermug.com](https://mermug.com).
+
+### Charging Sources
+
+| Source | Capacity | Notes |
+|--------|----------|-------|
+| Shore power charger | [A] / [W] | [make/model] |
+| Engine alternator | [A] | [size] |
+| Solar | [W] | [panel count, location, controller make/model] |
+| Wind gen | — | installed? |
+
+### Shore Power
+- **Inlet**: [30A / 50A], [location on boat]
+- **Converter/Charger**: [make/model], located [location]
+- Connects to dock pedestal via shore power cord; confirm polarity light is green.
+
+### DC Panel
+Located at nav station. Circuits labeled:
+- [List circuits as you learn them, e.g.:]
+  - 1: Navigation lights
+  - 2: VHF
+  - 3: Instruments
+  - 4: Cabin lights
+  - 5: Bilge pump (auto)
+  - 6: Anchor windlass (via breaker at bow)
+  - ...
+
+### AC Panel
+Located at [nav station / electrical panel].
+- Main breaker: [location]
+- Shore power breaker: [A]
+- Circuits: [list as known]
+
+### Inverter
+- **Make/Model**: —
+- Capacity: — W
+- Location: —
+- Note: do not run high-draw appliances (microwave, kettle) without engine running unless battery is at ≥80%.
+
+---
+
+## 5. Plumbing & Freshwater
+
+### Freshwater System
+
+| Spec | Value |
+|------|-------|
+| Tank capacity | — gallons |
+| Tank location | [under V-berth / settee / other] |
+| Pump | [make/model], [pressure switch or manual] |
+| Hot water heater | [engine heat exchanger / AC element / both?] |
+| Fill deck plate | [location] |
+
+### Freshwater Conservation
+Typical consumption underway: ~[X] gallons/day. Fill at marina before any offshore passage.
+
+### Head (Marine Toilet)
+
+| Spec | Value |
+|------|-------|
+| Type | [manual / electric] |
+| Make/Model | — |
+| Holding tank capacity | — gallons |
+| Holding tank location | [forward, under V-berth?] |
+| Pump-out deck fitting | [location] |
+| Overboard discharge Y-valve | [location] — confirm legal (offshore only outside 3 nm) |
+
+**Operating the head:**
+1. Open inlet seacock.
+2. [Manual: describe stroke procedure] / [Electric: describe button sequence]
+3. Close inlet seacock when done at anchor or in sensitive areas.
+
+**Pump-out**: at marina pump-out station or via [portable pump-out service].
+
+### Bilge
+
+- **Automatic bilge pump**: [location], float switch — activates automatically.
+- **Manual bilge pump**: [location — cockpit?]
+- **Inspection**: check bilge level on every departure; some accumulation (rain, condensation) is normal.
+
+### Seacocks & Through-Hulls
+
+| Location | Purpose | Normally |
+|----------|---------|---------|
+| Starboard under steps | Engine raw water intake | Open underway, closed at anchor/dock |
+| Forward [location] | Head intake | Open when using head |
+| [location] | Head discharge | Open when using head (offshore) |
+| [location] | Cockpit drains | Open |
+| [location] | Other | — |
+
+> Know every seacock. Be able to close them all in the dark.
+
+---
+
+## 6. Navigation & Electronics
+
+### Chartplotter / MFD
+- **Make/Model**: —
+- **Location**: Helm / nav station
+- Connected to: GPS antenna, AIS, instruments, depth
+- Charts loaded: —
+
+### VHF Radio
+- **Make/Model**: —
+- **Location**: Nav station / helm
+- DSC equipped: yes/no — MMSI programmed: **338543654**
+- Always monitor **Ch 16**.
+
+### AIS
+- **Type**: Class B transponder (transmit + receive)
+- **Make/Model**: —
+- Integrated with chartplotter; MMSI: **338543654**
+- Verify targets visible on chartplotter on departure.
+
+### Depth Sounder
+- **Make/Model**: —
+- Transducer location: [under hull, forward/aft of keel]
+- **Offset**: [keel depth below transducer: — ft] — displayed depth is from transducer, not keel.
+- Alarm: set for 10 ft below keel minimum.
+
+### Wind Instruments
+- **Masthead unit**: [make/model]
+- Displays: apparent wind angle, apparent wind speed; converts to true wind via boat speed/COG.
+- Note any calibration offsets here when determined.
+
+### Autopilot
+- **Make/Model**: —
+- **Type**: [below-decks ram / wheel drive / tiller]
+- **Control head location**: helm
+- Limits: [max sea state / wind it's trusted in]
+
+### Compass
+- **Location**: binnacle
+- **Deviation card**: [on file / not yet swung]
+
+### Radar
+- **Installed**: [yes / no]
+- **Make/Model**: —
+- **Type**: [dome / open array], [kW], [range]
+
+### SignalK Server
+- Running on Raspberry Pi at `192.168.8.50:3000`.
+- Aggregates all NMEA/instrument data onboard.
+- Feeds the KIP display (main instrument dashboard) and the mermug.com tracker.
+- See the [mermug.com tracker repo](https://github.com/zackphillips/zackphillips.github.io) for the telemetry pipeline.
+
+---
+
+## 7. Safety Equipment
+
+| Item | Quantity | Location | Expiry/Service |
+|------|----------|----------|----------------|
+| Life jackets (USCG approved) | — | [location] | Inspect annually |
+| Horseshoe buoy | 1 | Stern rail | — |
+| Throwable cushion (Type IV) | 1 | Cockpit | — |
+| Handheld flares | — | [location] | [date] |
+| Parachute flares | — | [location] | [date] |
+| Smoke signals | — | [location] | [date] |
+| EPIRB | 1 | [location] | Battery: [date]; Registration: [date] |
+| PLB(s) | — | [location] | — |
+| Fire extinguishers | — | [locations] | [service date] |
+| Life raft | [yes/no] | [location] | Inspect: [date] |
+| Ditch bag | 1 | [location] | Contents current: [date] |
+| Tethers / jacklines | — | [location] | — |
+| Harnesses | — | [location] | — |
+
+### Ditch Bag Contents
+- [ ] EPIRB / PLB
+- [ ] Handheld VHF (charged)
+- [ ] Flares (in-date)
+- [ ] Water (1 liter minimum per person)
+- [ ] Knife
+- [ ] Mirror
+- [ ] Copies of ship's papers
+- [ ] Cash
+- [ ] First aid
+- [ ] [any boat-specific additions]
+
+---
+
+## 8. Ground Tackle
+
+### Primary Anchor
+- **Type**: Delta (plough)
+- **Weight**: 35 lb
+- **Chain**: 200 ft, 5/16" BBB or G40
+- **Rode**: 150 ft, 5/8" nylon
+- **Storage**: bow anchor locker, starboard side
+
+### Secondary Anchor
+- **Type**: —
+- **Weight**: —
+- **Rode**: —
+- **Storage**: —
+
+### Windlass
+- **Make/Model**: —
+- **Type**: electric, foot switches at bow
+- **Breaker**: nav station, [circuit label]
+- **Manual override**: [location]
+- **Note**: do not run more than [X] minutes continuously; allow to cool.
+
+---
+
+## 9. Sails & Running Rigging
+
+### Inventory
+
+| Sail | Type | Area (sq ft) | Condition | Notes |
+|------|------|-------------|-----------|-------|
+| Main | [full-batten / partial-batten] | — | — | In-mast or on boom? |
+| Headsail #1 (genoa) | [% overlap] | — | — | Furling |
+| Headsail #2 (working jib) | — | — | — | [hanked / furling] |
+| Spinnaker | [sym / asym] | — | — | — |
+| Storm jib | — | — | — | [hanked to inner stay?] |
+| Trysail | [yes/no] | — | — | — |
+
+### Running Rigging Summary
+
+| Line | Purpose | Color/ID | Clutch/Cleat |
+|------|---------|----------|-------------|
+| Main halyard | Raise/lower main | — | [mast cleat / clutch] |
+| Jib halyard | Raise/lower headsail | — | — |
+| Mainsheet | Main trim | — | Traveler block to cleat |
+| Port jib sheet | Headsail trim | — | — |
+| Starboard jib sheet | Headsail trim | — | — |
+| Vang | Leech tension | — | — |
+| Cunningham | Luff tension | — | — |
+| Outhaul | Foot tension | — | — |
+| Reef 1 | First reef, leech | — | — |
+| Reef 2 | Second reef, leech | — | — |
+| Furling line (headsail) | Furl/unfurl headsail | — | — |
+| Topping lift | Boom support | — | — |
+
+### Sail Trim Notes
+- [Add boat-specific tuning notes here over time — e.g., twist preferences, backstay settings for conditions]
+
+---
+
+## 10. Vessel Data / Automation
+
+### SignalK
+- **Server**: Raspberry Pi at `192.168.8.50:3000`
+- Aggregates NMEA 2000 / NMEA 0183 instruments.
+- Web interface at `http://192.168.8.50:3000` on local vessel network.
+
+### KIP (Instrument Display)
+- Running on [tablet / dedicated display] at helm / nav station.
+- Connects to SignalK server; shows real-time wind, speed, depth, heading.
+
+### Telemetry Pipeline (mermug.com)
+- Python script (`scripts/update_signalk_data.py`) polls SignalK every ~150 sec.
+- Writes JSON to `data/telemetry/` and commits to GitHub.
+- GitHub Pages serves the static site.
+- Privacy zone suppresses positions within 200 m of South Beach Harbor.
+- See [AGENTS.md](../AGENTS.md) and [README.md](../README.md) for full technical details.
+
+### Raspberry Pi
+- **Location**: [nav station / electrical compartment]
+- **OS**: Raspberry Pi OS (bookworm or later)
+- **Services**: `mermug-website.service`, `mermug-polars.service`
+- Manage via `make status`, `make show-logs-website`
+- Pi connects to the internet via [marina WiFi / cellular / both].


### PR DESCRIPTION
## Summary

Adds a `docs/` folder with three skeleton documents for S.V. Mermug:

- **`docs/operations.md`** — Pre-departure checklists, engine start/stop procedure, leaving/returning to slip, sail handling (hoist, furl, reef), anchoring, and emergency procedures (MOB, fire, flooding, engine failure, radio Mayday format).
- **`docs/changelog.md`** — Running vessel upgrade/repair log with a recurring maintenance schedule table and a parts/specs reference table. The tracker deployment entry is pre-filled; everything else is ready to fill in.
- **`docs/systems.md`** — Full systems reference covering hull & rig, engine & drive, fuel, electrical (batteries, charging, DC/AC panels), plumbing & freshwater, nav & electronics (SignalK, KIP, chartplotter, AIS, autopilot), safety gear, ground tackle, sails & running rigging, and the vessel telemetry pipeline.

All docs are pre-filled with S.V. Mermug specifics where known (dimensions, MMSI, home berth, SignalK host, privacy zone, telemetry architecture). Fields that need to be filled in are marked with `—` or `[placeholder]`.

## Test plan

- [ ] Review each file for accuracy against actual boat specs and fill in `—` placeholders
- [ ] Add a real changelog entry for the first boat modification or maintenance event
- [ ] Confirm operations procedures match actual boat SOPs

https://claude.ai/code/session_01XfyEoMePXnX6bBFkQGz2gg

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfyEoMePXnX6bBFkQGz2gg)_