### PR TITLE
Add PostgSail logs link and move buttons above map

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -953,17 +953,24 @@ function updateVesselLinks() {
   }
 
   // Construct external tracking links
+  vesselData.links = vesselData.links || {};
   if (vesselData.marinetraffic_ship_id) {
-    vesselData.links = {
-      marinetraffic: `https://www.marinetraffic.com/en/ais/details/ships/shipid:${vesselData.marinetraffic_ship_id}`
-    };
+    vesselData.links.marinetraffic = `https://www.marinetraffic.com/en/ais/details/ships/shipid:${vesselData.marinetraffic_ship_id}`;
+  }
+  if (vesselData.postgsail_logs_url) {
+    vesselData.links.postgsail = vesselData.postgsail_logs_url;
   }
 
   // Update AIS links
   const marinetrafficLink = document.getElementById('marinetraffic-link');
-
   if (marinetrafficLink && vesselData.links?.marinetraffic) {
     marinetrafficLink.href = vesselData.links.marinetraffic;
+  }
+
+  const postgsailLink = document.getElementById('postgsail-link');
+  if (postgsailLink && vesselData.links?.postgsail) {
+    postgsailLink.href = vesselData.links.postgsail;
+    postgsailLink.style.display = '';
   }
 }
 let themeChangeTimeout = null; // Timeout for theme change debouncing

--- a/data/vessel/info.yaml
+++ b/data/vessel/info.yaml
@@ -9,6 +9,7 @@ theme: "mermug"   # light | dark | mermug | deep-sea | starboard | port-light | 
 name: "S.V.Mermug"
 mmsi: "338543654"
 marinetraffic_ship_id: "9698083"
+postgsail_logs_url: "https://iot.openplotter.cloud/SVMermug/logs"
 uscg_number: "1024168"
 hull_number: "BEY57004E494"
 signalk:

--- a/index.html
+++ b/index.html
@@ -57,6 +57,14 @@
       </div>
     </div>
 
+    <!-- LINKS -->
+    <div class="links-section">
+      <div class="button-row">
+        <a href="#" id="marinetraffic-link" target="_blank" class="action-btn ais-btn">MarineTraffic</a>
+        <a href="#" id="postgsail-link" target="_blank" class="action-btn ais-btn" style="display:none;">PostgSail Logs</a>
+      </div>
+    </div>
+
     <!-- MAP -->
     <div class="map-section">
       <div id="map"></div>
@@ -64,13 +72,6 @@
 
     <!-- PASSAGE BANNER (shown only when passage is set in info.yaml) -->
     <div id="passage-banner" class="passage-banner" style="display:none;"></div>
-
-    <!-- LINKS -->
-    <div class="links-section">
-      <div class="button-row">
-        <a href="#" id="marinetraffic-link" target="_blank" class="action-btn ais-btn">MarineTraffic</a>
-      </div>
-    </div>
 
     <div class="content-panels">
 


### PR DESCRIPTION
## Summary\n- Adds a \"PostgSail Logs\" button linking to https://iot.openplotter.cloud/SVMermug/logs, shown next to the MarineTraffic button\n- Moves the button row above the map (was previously below it)\n- Adds `postgsail_logs_url` field to `data/vessel/info.yaml`\n- Wires up the link in `assets/app.js` using the new YAML field

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcK2ifVdZfs13VEPjHeqFL)_